### PR TITLE
Adding back the fixes to libovsdb.

### DIFF
--- a/vendor/github.com/socketplane/libovsdb/client.go
+++ b/vendor/github.com/socketplane/libovsdb/client.go
@@ -58,6 +58,7 @@ func ConnectUsingProtocol(protocol string, target string) (*OvsdbClient, error) 
 	}
 
 	c := rpc2.NewClientWithCodec(jsonrpc.NewJSONCodec(conn))
+	c.SetBlocking(true)
 	c.Handle("echo", echo)
 	c.Handle("update", update)
 	go c.Run()

--- a/vendor/github.com/socketplane/libovsdb/set.go
+++ b/vendor/github.com/socketplane/libovsdb/set.go
@@ -24,7 +24,7 @@ func NewOvsSet(goSlice interface{}) (*OvsSet, error) {
 		return nil, errors.New("OvsSet supports only Go Slice types")
 	}
 
-	var ovsSet []interface{}
+	var ovsSet []interface{} = []interface{}{}
 	for i := 0; i < v.Len(); i++ {
 		ovsSet = append(ovsSet, v.Index(i).Interface())
 	}


### PR DESCRIPTION
Commit 340f8e3d overwritten the patches we added for libovsdb. Those
patches are required for goovn to work properly. The tests were broken.
This patch adds those changes back. The fixes overwritten are:

6800727 Json marshal should be array of zero size, not null
0d9b1b7 NTWK-2550: fix libovndb cache update problem