### PR TITLE
Fix LB delete operation for all ovn versions:

### DIFF
--- a/ovnnbimp.go
+++ b/ovnnbimp.go
@@ -133,6 +133,22 @@ func (odbi *ovnDBImp) getRowUUIDContainsUUID(table, field, uuid string) (string,
 	return "", ErrorNotFound
 }
 
+func (odbi *ovnDBImp) getRowsMatchingUUID(table, field, uuid string) ([]string, error) {
+	odbi.cachemutex.Lock()
+	defer odbi.cachemutex.Unlock()
+	var uuids []string
+	for id, drows := range odbi.cache[table] {
+		v := fmt.Sprintf("%s", drows.Fields[field])
+		if strings.Contains(v, uuid) {
+			uuids = append(uuids, id)
+		}
+	}
+	if len(uuids) == 0 {
+		return uuids, ErrorNotFound
+	}
+	return uuids, nil
+}
+
 func (odbi *ovnDBImp) transact(ops ...libovsdb.Operation) ([]libovsdb.OperationResult, error) {
 	// Only support one trans at same time now.
 	odbi.tranmutex.Lock()

--- a/ovnnbimp_test.go
+++ b/ovnnbimp_test.go
@@ -458,7 +458,7 @@ func TestLoadBalancer(t *testing.T) {
 
 	t.Logf("Deleting LB")
 	ocmd, err = ovndbapi.LBDel("lb1")
-	if err != nil {
+	if err != nil && err != ErrorNotFound {
 		t.Fatal(err)
 	}
 	err = ovndbapi.Execute(ocmd)


### PR DESCRIPTION
Creating LB will add load_balancer entries in all logical switches in ovn
to ensure routing is taken care within all the lswitches for the particular vip.
However, delete lb doesnt iterate to all the lswitches and hence lb
delete fails saying multiple references found accross multiple switches.
Hence, we need to clean up lbuuid from all lswitches to avoid this error.
Newer versions of OVN do handle this condition by default where delete LB
will delete all the references too. So, adding this support for environments
using older ovn versions