### PR TITLE
align method names with ovn-nbctl

### DIFF
--- a/acl_test.go
+++ b/acl_test.go
@@ -28,7 +28,7 @@ func TestACLs(t *testing.T) {
 	var err error
 
 	cmds = make([]*OvnCommand, 0)
-	cmd, err = ovndbapi.LSWAdd(LSW)
+	cmd, err = ovndbapi.LSAdd(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestACLs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lsws, err := ovndbapi.GetLogicalSwitches()
+	lsws, err := ovndbapi.LSList()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestACLs(t *testing.T) {
 		t.Fatalf("ls not created %d", len(lsws))
 	}
 
-	lsps, err := ovndbapi.GetLogicalSwitchPortsBySwitch(LSW)
+	lsps, err := ovndbapi.LSPList(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func TestACLs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lsps, err = ovndbapi.GetLogicalSwitchPortsBySwitch(LSW)
+	lsps, err = ovndbapi.LSPList(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestACLs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lsps, err = ovndbapi.GetLogicalSwitchPortsBySwitch(LSW)
+	lsps, err = ovndbapi.LSPList(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,14 +218,14 @@ func TestACLs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lsps, err = ovndbapi.GetLogicalSwitchPortsBySwitch(LSW)
+	lsps, err = ovndbapi.LSPList(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assert.Equal(t, true, len(lsps) == 0, "test[%s]", "one port remove")
 
-	cmd, err = ovndbapi.LSWDel(LSW)
+	cmd, err = ovndbapi.LSDel(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,4 +235,3 @@ func TestACLs(t *testing.T) {
 	}
 
 }
-

--- a/apis.go
+++ b/apis.go
@@ -33,56 +33,69 @@ type Execution interface {
 
 // North bound api set
 type OVNDBApi interface {
-	// Create a logical switch named SWITCH
-	LSWAdd(lsw string) (*OvnCommand, error)
-	//delete SWITCH and all its ports
-	LSWDel(lsw string) (*OvnCommand, error)
-	// Print the names of all logical switches
-	LSWList() (*OvnCommand, error)
+	// Create ls named SWITCH
+	LSAdd(ls string) (*OvnCommand, error)
+	// Del ls and all its ports
+	LSDel(ls string) (*OvnCommand, error)
+	// Get all logical switches
+	LSList() ([]*LogicalSwitch, error)
+
 	// Add logical port PORT on SWITCH
-	LSPAdd(lsw, lsp string) (*OvnCommand, error)
+	LSPAdd(ls string, lsp string) (*OvnCommand, error)
 	// Delete PORT from its attached switch
 	LSPDel(lsp string) (*OvnCommand, error)
 	// Set addressset per lport
 	LSPSetAddress(lsp string, addresses ...string) (*OvnCommand, error)
 	// Set port security per lport
 	LSPSetPortSecurity(lsp string, security ...string) (*OvnCommand, error)
+	// Get all lport by lswitch
+	LSPList(ls string) ([]*LogicalSwitchPort, error)
+
 	// Add LB to LSW
 	LSLBAdd(lswitch string, lb string) (*OvnCommand, error)
 	// Delete LB from LSW
 	LSLBDel(lswitch string, lb string) (*OvnCommand, error)
 	// List Load balancers for a LSW
 	LSLBList(lswitch string) ([]*LoadBalancer, error)
+
 	// Add ACL
 	ACLAdd(lsw, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter string) (*OvnCommand, error)
 	// Delete acl
 	ACLDel(lsw, direct, match string, priority int, external_ids map[string]string) (*OvnCommand, error)
+
 	// Update address set
 	ASUpdate(name string, addrs []string, external_ids map[string]string) (*OvnCommand, error)
 	// Add addressset
 	ASAdd(name string, addrs []string, external_ids map[string]string) (*OvnCommand, error)
 	// Delete addressset
 	ASDel(name string) (*OvnCommand, error)
+
 	// Add LR with given name
 	LRAdd(name string, external_ids map[string]string) (*OvnCommand, error)
 	// Delete LR with given name
 	LRDel(name string) (*OvnCommand, error)
+	// Get LRs
+	LRList() ([]*LogicalRouter, error)
+
 	// Add LRP with given name on given lr
 	LRPAdd(lr string, lrp string, mac string, network []string, peer string, external_ids map[string]string) (*OvnCommand, error)
 	// Delete LRP with given name on given lr
 	LRPDel(lr string, lrp string) (*OvnCommand, error)
+
 	// Add LB to LR
 	LRLBAdd(lr string, lb string) (*OvnCommand, error)
 	// Delete LB from LR
 	LRLBDel(lr string, lb string) (*OvnCommand, error)
 	// List Load balancers for a LR
 	LRLBList(lr string) ([]*LoadBalancer, error)
+
 	// Add LB
 	LBAdd(name string, vipPort string, protocol string, addrs []string) (*OvnCommand, error)
 	// Delete LB with given name
 	LBDel(name string) (*OvnCommand, error)
 	// Update existing LB
 	LBUpdate(name string, vipPort string, protocol string, addrs []string) (*OvnCommand, error)
+
 	// Set dhcp4_options uuid on lsp
 	LSPSetDHCPv4Options(lsp string, options string) (*OvnCommand, error)
 	// Get dhcp4_options from lsp
@@ -96,28 +109,23 @@ type OVNDBApi interface {
 	LSPSetOpt(lsp string, options map[string]string) (*OvnCommand, error)
 
 	// Add dhcp options for cidr and provided external_ids
-	AddDHCPOptions(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error)
+	DHCPOptionsAdd(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error)
 	// Set dhcp options for specific cidr and provided external_ids
-	SetDHCPOptions(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error)
+	DHCPOptionsSet(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error)
 	// Del dhcp options via provided external_ids
-	DelDHCPOptions(uuid string) (*OvnCommand, error)
+	DHCPOptionsDel(uuid string) (*OvnCommand, error)
+	// List dhcp options
+	DHCPOptionsList() ([]*DHCPOptions, error)
 
 	// Add qos rule
 	QoSAdd(ls string, direction string, priority int, match string, action map[string]int, bandwidth map[string]int, external_ids map[string]string) (*OvnCommand, error)
 	// Del qos rule, to delete wildcard specify priority -1 and string options as ""
 	QoSDel(ls string, direction string, priority int, match string) (*OvnCommand, error)
-	// Get qos rules by logical switch name
-	GetQoSBySwitch(ls string) ([]*QoS, error)
-
-	// Exec command, support mul-commands in one transaction.
-	Execute(cmds ...*OvnCommand) error
+	// Get qos rules by logical switch
+	QoSList(ls string) ([]*QoS, error)
 
 	// Get logical switch by name
 	GetLogicalSwitchByName(ls string) (*LogicalSwitch, error)
-	// Get all logical switches
-	GetLogicalSwitches() ([]*LogicalSwitch, error)
-	// Get all lport by lswitch
-	GetLogicalSwitchPortsBySwitch(lsw string) ([]*LogicalSwitchPort, error)
 	// Get all lrp by lr
 	GetLogicalRouterPortsByRouter(lr string) ([]*LogicalRouterPort, error)
 
@@ -128,12 +136,11 @@ type OVNDBApi interface {
 	GetASByName(name string) (*AddressSet, error)
 	// Get LB with given name
 	GetLB(name string) ([]*LoadBalancer, error)
-	// Get dhcp options
-	GetDHCPOptions() ([]*DHCPOptions, error)
 	// Get LR with given name
 	GetLogicalRouter(name string) ([]*LogicalRouter, error)
-	// Get LRs
-	GetLogicalRouters() ([]*LogicalRouter, error)
+
+	// Exec command, support mul-commands in one transaction.
+	Execute(cmds ...*OvnCommand) error
 	SetCallBack(callback OVNSignal)
 }
 

--- a/dhcp_options.go
+++ b/dhcp_options.go
@@ -69,7 +69,7 @@ func newDHCPRow(cidr string, options map[string]string, external_ids map[string]
 	return row, nil
 }
 
-func (odbi *ovnDBImp) addDHCPOptionsImp(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error) {
+func (odbi *ovnDBImp) dhcpOptionsAddImp(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error) {
 	namedUUID, err := newRowUUID()
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func (odbi *ovnDBImp) addDHCPOptionsImp(cidr string, options map[string]string, 
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
-func (odbi *ovnDBImp) setDHCPOptionsImp(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error) {
+func (odbi *ovnDBImp) dhcpOptionsSetImp(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error) {
 
 	row, err := newDHCPRow(cidr, nil, external_ids)
 	if err != nil {
@@ -118,7 +118,7 @@ func (odbi *ovnDBImp) setDHCPOptionsImp(cidr string, options map[string]string, 
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
-func (odbi *ovnDBImp) delDHCPOptionsImp(uuid string) (*OvnCommand, error) {
+func (odbi *ovnDBImp) dhcpOptionsDelImp(uuid string) (*OvnCommand, error) {
 	condition := libovsdb.NewCondition("_uuid", "==", libovsdb.UUID{uuid})
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
@@ -129,20 +129,8 @@ func (odbi *ovnDBImp) delDHCPOptionsImp(uuid string) (*OvnCommand, error) {
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
-func (odbi *ovnDBImp) dhcpOptionsListImp() (*OvnCommand, error) {
-	condition := libovsdb.NewCondition("name", "!=", "")
-	selectOp := libovsdb.Operation{
-		Op:    opSelect,
-		Table: tableDHCPOptions,
-		Where: []interface{}{condition},
-	}
-
-	operations := []libovsdb.Operation{selectOp}
-	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
-}
-
-// Get all dhcp options
-func (odbi *ovnDBImp) getDHCPOptionsImp() ([]*DHCPOptions, error) {
+// List all dhcp options
+func (odbi *ovnDBImp) dhcpOptionsListImp() ([]*DHCPOptions, error) {
 	var listDHCP []*DHCPOptions
 
 	odbi.cachemutex.RLock()

--- a/dhcp_options_test.go
+++ b/dhcp_options_test.go
@@ -28,7 +28,7 @@ func TestDHCPOptions(t *testing.T) {
 	var err error
 
 	cmds = make([]*OvnCommand, 0)
-	cmd, err = ovndbapi.LSWAdd(LSW)
+	cmd, err = ovndbapi.LSAdd(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestDHCPOptions(t *testing.T) {
 	}
 	cmds = append(cmds, cmd)
 
-	cmd, err = ovndbapi.AddDHCPOptions(
+	cmd, err = ovndbapi.DHCPOptionsAdd(
 		"192.168.0.0/24",
 		map[string]string{
 			"server_id":  "192.168.1.1",
@@ -62,7 +62,7 @@ func TestDHCPOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lsws, err := ovndbapi.GetLogicalSwitches()
+	lsws, err := ovndbapi.LSList()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestDHCPOptions(t *testing.T) {
 		t.Fatalf("ls not created %d", len(lsws))
 	}
 
-	dhcp_opts, err := ovndbapi.GetDHCPOptions()
+	dhcp_opts, err := ovndbapi.DHCPOptionsList()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestDHCPOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lsps, err := ovndbapi.GetLogicalSwitchPortsBySwitch(LSW)
+	lsps, err := ovndbapi.LSPList(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestDHCPOptions(t *testing.T) {
 	assert.Equal(t, true, len(lsps) == 1 && lsps[0].Name == LSP, "test[%s]: %v", "added port", lsps)
 	assert.Equal(t, true, len(lsps) == 1 && lsps[0].DHCPv4Options != "", "test[%s]", "setted dhcpv4_options")
 
-	cmd, err = ovndbapi.DelDHCPOptions(dhcp_opts[0].UUID)
+	cmd, err = ovndbapi.DHCPOptionsDel(dhcp_opts[0].UUID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestDHCPOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dhcp_opts, err = ovndbapi.GetDHCPOptions()
+	dhcp_opts, err = ovndbapi.DHCPOptionsList()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,14 +127,14 @@ func TestDHCPOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lsps, err = ovndbapi.GetLogicalSwitchPortsBySwitch(LSW)
+	lsps, err = ovndbapi.LSPList(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assert.Equal(t, true, len(lsps) == 0, "test[%s]", "one port remove")
 
-	cmd, err = ovndbapi.LSWDel(LSW)
+	cmd, err = ovndbapi.LSDel(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples/main.go
+++ b/examples/main.go
@@ -44,14 +44,14 @@ func init() {
 
 func main() {
 
-	ocmd, _ := ovndbapi.LSWAdd("ls1")
+	ocmd, _ := ovndbapi.LSAdd("ls1")
 	ovndbapi.Execute(ocmd)
 	ocmd, _ = ovndbapi.LSPAdd("ls1", "test")
 	ovndbapi.Execute(ocmd)
 	ocmd, _ = ovndbapi.LSPSetAddress("test", "12:34:56:78:90 10.10.10.1")
 	ovndbapi.Execute(ocmd)
 
-	lports, _ := ovndbapi.GetLogicalSwitchPortsBySwitch("ls1")
+	lports, _ := ovndbapi.LSPList("ls1")
 	for _, lp := range lports {
 		fmt.Printf("%v\n", *lp)
 	}
@@ -94,7 +94,7 @@ func main() {
 	}
 	ocmd, _ = ovndbapi.LSPDel("test")
 	ovndbapi.Execute(ocmd)
-	ocmd, _ = ovndbapi.LSWDel("ls1")
+	ocmd, _ = ovndbapi.LSDel("ls1")
 	ovndbapi.Execute(ocmd)
 
 }

--- a/logical_router.go
+++ b/logical_router.go
@@ -129,7 +129,7 @@ func (odbi *ovnDBImp) rowToLogicalRouter(uuid string) *LogicalRouter {
 }
 
 // Get all logical switches
-func (odbi *ovnDBImp) GetLogicalRouters() ([]*LogicalRouter, error) {
+func (odbi *ovnDBImp) lrListImp() ([]*LogicalRouter, error) {
 	var listLR []*LogicalRouter
 
 	odbi.cachemutex.RLock()

--- a/logical_router_port_test.go
+++ b/logical_router_port_test.go
@@ -18,7 +18,7 @@ func TestLogicalRouterPort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lrs, err := ovndbapi.GetLogicalRouters()
+	lrs, err := ovndbapi.LRList()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestLogicalRouterPort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lrs, err = ovndbapi.GetLogicalRouters()
+	lrs, err = ovndbapi.LRList()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/logical_router_test.go
+++ b/logical_router_test.go
@@ -18,7 +18,7 @@ func TestLogicalRouter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lrs, err := ovndbapi.GetLogicalRouters()
+	lrs, err := ovndbapi.LRList()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func TestLogicalRouter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lrs, err = ovndbapi.GetLogicalRouters()
+	lrs, err = ovndbapi.LRList()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/logical_switch.go
+++ b/logical_switch.go
@@ -33,19 +33,7 @@ type LogicalSwitch struct {
 	ExternalID   map[interface{}]interface{}
 }
 
-func (odbi *ovnDBImp) lswListImp() (*OvnCommand, error) {
-	condition := libovsdb.NewCondition("name", "!=", "")
-	selectOp := libovsdb.Operation{
-		Op:    opSelect,
-		Table: tableLogicalSwitch,
-		Where: []interface{}{condition},
-	}
-
-	operations := []libovsdb.Operation{selectOp}
-	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
-}
-
-func (odbi *ovnDBImp) lswAddImp(lsw string) (*OvnCommand, error) {
+func (odbi *ovnDBImp) lsAddImp(lsw string) (*OvnCommand, error) {
 	namedUUID, err := newRowUUID()
 	if err != nil {
 		return nil, err
@@ -69,7 +57,7 @@ func (odbi *ovnDBImp) lswAddImp(lsw string) (*OvnCommand, error) {
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
-func (odbi *ovnDBImp) lswDelImp(lsw string) (*OvnCommand, error) {
+func (odbi *ovnDBImp) lsDelImp(lsw string) (*OvnCommand, error) {
 	condition := libovsdb.NewCondition("name", "==", lsw)
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
@@ -154,8 +142,7 @@ func (odbi *ovnDBImp) GetLogicalSwitchByName(ls string) (*LogicalSwitch, error) 
 	return nil, ErrorNotFound
 }
 
-// Get all logical switches
-func (odbi *ovnDBImp) GetLogicalSwitches() ([]*LogicalSwitch, error) {
+func (odbi *ovnDBImp) lsListImp() ([]*LogicalSwitch, error) {
 	var listLS []*LogicalSwitch
 
 	odbi.cachemutex.RLock()

--- a/logical_switch_load_balancer_test.go
+++ b/logical_switch_load_balancer_test.go
@@ -17,19 +17,20 @@
 package goovn
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
-	LB3 = "lb3"
+	LB3  = "lb3"
 	LSW1 = "LSW1"
 )
 
 func TestLSLoadBalancer(t *testing.T) {
 	// create Switch
 	t.Logf("Adding  %s to OVN", LSW1)
-	cmd, err := ovndbapi.LSWAdd(LSW1)
+	cmd, err := ovndbapi.LSAdd(LSW1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +76,7 @@ func TestLSLoadBalancer(t *testing.T) {
 		t.Fatalf("lbs not created in %s", LSW1)
 	}
 	assert.Equal(t, true, lbs[0].Name == LB3, "Added lb to lswitch")
-    // delete lb from switch
+	// delete lb from switch
 	t.Logf("Deleting LB LB3 to LSW1itches %s", LSW1)
 	cmd, err = ovndbapi.LSLBDel(LSW1, LB3)
 	if err != nil {
@@ -86,13 +87,13 @@ func TestLSLoadBalancer(t *testing.T) {
 		t.Fatalf("Deleting LB LB3 to LSW1itch failed with err %v", err)
 	}
 	t.Logf("Deleting LB LB3 to LSW1itch %s Done", LSW1)
-    // verify lb deletion from switch
+	// verify lb deletion from switch
 	lbs, err = ovndbapi.LSLBList(LSW1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, true, len(lbs) == 0, "Deleted lb from lswitch")
-    // Delete LB
+	// Delete LB
 	t.Logf("Deleting LB")
 	cmd, err = ovndbapi.LBDel(LB3)
 	if err != nil && err != ErrorNotFound {
@@ -104,7 +105,7 @@ func TestLSLoadBalancer(t *testing.T) {
 	}
 	// Finally delete Switch
 	t.Logf("Deleting LS")
-	cmd, err = ovndbapi.LSWDel(LSW1)
+	cmd, err = ovndbapi.LSDel(LSW1)
 	if err != nil && err != ErrorNotFound {
 		t.Fatal(err)
 	}

--- a/logical_switch_port.go
+++ b/logical_switch_port.go
@@ -278,7 +278,7 @@ func (odbi *ovnDBImp) GetLogicalSwitchPortByName(lsp string) (*LogicalSwitchPort
 }
 
 // Get all lport by lswitch
-func (odbi *ovnDBImp) GetLogicalSwitchPortsBySwitch(lsw string) ([]*LogicalSwitchPort, error) {
+func (odbi *ovnDBImp) LSPList(lsw string) ([]*LogicalSwitchPort, error) {
 	var listLSP []*LogicalSwitchPort
 
 	odbi.cachemutex.RLock()

--- a/ovnnb.go
+++ b/ovnnb.go
@@ -89,16 +89,16 @@ func newNBByServer(server string, port int, callback OVNSignal, protocol string)
 	return &OVNDB{imp}, nil
 }
 
-func (odb *OVNDB) LSWAdd(lsw string) (*OvnCommand, error) {
-	return odb.imp.lswAddImp(lsw)
+func (odb *OVNDB) LSAdd(lsw string) (*OvnCommand, error) {
+	return odb.imp.lsAddImp(lsw)
 }
 
-func (odb *OVNDB) LSWDel(lsw string) (*OvnCommand, error) {
-	return odb.imp.lswDelImp(lsw)
+func (odb *OVNDB) LSDel(lsw string) (*OvnCommand, error) {
+	return odb.imp.lsDelImp(lsw)
 }
 
-func (odb *OVNDB) LSWList() (*OvnCommand, error) {
-	return odb.imp.lswListImp()
+func (odb *OVNDB) LSList() ([]*LogicalSwitch, error) {
+	return odb.imp.lsListImp()
 }
 
 func (odb *OVNDB) LSPAdd(lsw string, lsp string) (*OvnCommand, error) {
@@ -115,6 +115,26 @@ func (odb *OVNDB) LSPSetAddress(lsp string, addresses ...string) (*OvnCommand, e
 
 func (odb *OVNDB) LSPSetPortSecurity(lsp string, security ...string) (*OvnCommand, error) {
 	return odb.imp.lspSetPortSecurityImp(lsp, security...)
+}
+
+func (odb *OVNDB) LSPSetDHCPv4Options(lsp string, options string) (*OvnCommand, error) {
+	return odb.imp.LSPSetDHCPv4Options(lsp, options)
+}
+
+func (odb *OVNDB) LSPGetDHCPv4Options(lsp string) (*DHCPOptions, error) {
+	return odb.imp.LSPGetDHCPv4Options(lsp)
+}
+
+func (odb *OVNDB) LSPSetDHCPv6Options(lsp string, options string) (*OvnCommand, error) {
+	return odb.imp.LSPSetDHCPv6Options(lsp, options)
+}
+
+func (odb *OVNDB) LSPGetDHCPv6Options(lsp string) (*DHCPOptions, error) {
+	return odb.imp.LSPGetDHCPv6Options(lsp)
+}
+
+func (odb *OVNDB) LSPSetOpt(lsp string, options map[string]string) (*OvnCommand, error) {
+	return odb.imp.LSPSetOpt(lsp, options)
 }
 
 func (odb *OVNDB) LSLBAdd(lswitch string, lb string) (*OvnCommand, error) {
@@ -135,6 +155,10 @@ func (odb *OVNDB) LRAdd(name string, external_ids map[string]string) (*OvnComman
 
 func (odb *OVNDB) LRDel(name string) (*OvnCommand, error) {
 	return odb.imp.lrDelImp(name)
+}
+
+func (odb *OVNDB) LRList() ([]*LogicalRouter, error) {
+	return odb.imp.lrListImp()
 }
 
 func (odb *OVNDB) LRPAdd(lr string, lrp string, mac string, network []string, peer string, external_ids map[string]string) (*OvnCommand, error) {
@@ -189,26 +213,6 @@ func (odb *OVNDB) ASUpdate(name string, addrs []string, external_ids map[string]
 	return odb.imp.ASUpdate(name, addrs, external_ids)
 }
 
-func (odb *OVNDB) LSPSetDHCPv4Options(lsp string, options string) (*OvnCommand, error) {
-	return odb.imp.LSPSetDHCPv4Options(lsp, options)
-}
-
-func (odb *OVNDB) LSPGetDHCPv4Options(lsp string) (*DHCPOptions, error) {
-	return odb.imp.LSPGetDHCPv4Options(lsp)
-}
-
-func (odb *OVNDB) LSPSetDHCPv6Options(lsp string, options string) (*OvnCommand, error) {
-	return odb.imp.LSPSetDHCPv6Options(lsp, options)
-}
-
-func (odb *OVNDB) LSPGetDHCPv6Options(lsp string) (*DHCPOptions, error) {
-	return odb.imp.LSPGetDHCPv6Options(lsp)
-}
-
-func (odb *OVNDB) LSPSetOpt(lsp string, options map[string]string) (*OvnCommand, error) {
-	return odb.imp.LSPSetOpt(lsp, options)
-}
-
 func (odb *OVNDB) QoSAdd(ls string, direction string, priority int, match string, action map[string]int, bandwidth map[string]int, external_ids map[string]string) (*OvnCommand, error) {
 	return odb.imp.addQoSImp(ls, direction, priority, match, action, bandwidth, external_ids)
 }
@@ -217,7 +221,7 @@ func (odb *OVNDB) QoSDel(ls string, direction string, priority int, match string
 	return odb.imp.delQoSImp(ls, direction, priority, match)
 }
 
-func (odb *OVNDB) GetQoSBySwitch(ls string) ([]*QoS, error) {
+func (odb *OVNDB) QoSList(ls string) ([]*QoS, error) {
 	return odb.imp.listQoSImp(ls)
 }
 
@@ -229,12 +233,8 @@ func (odb *OVNDB) GetLogicalSwitchByName(ls string) (*LogicalSwitch, error) {
 	return odb.imp.GetLogicalSwitchByName(ls)
 }
 
-func (odb *OVNDB) GetLogicalSwitches() ([]*LogicalSwitch, error) {
-	return odb.imp.GetLogicalSwitches()
-}
-
-func (odb *OVNDB) GetLogicalSwitchPortsBySwitch(lsw string) ([]*LogicalSwitchPort, error) {
-	return odb.imp.GetLogicalSwitchPortsBySwitch(lsw)
+func (odb *OVNDB) LSPList(lsw string) ([]*LogicalSwitchPort, error) {
+	return odb.imp.LSPList(lsw)
 }
 
 func (odb *OVNDB) GetLogicalRouterPortsByRouter(lr string) ([]*LogicalRouterPort, error) {
@@ -257,28 +257,24 @@ func (odb *OVNDB) GetLogicalRouter(name string) ([]*LogicalRouter, error) {
 	return odb.imp.GetLogicalRouter(name)
 }
 
-func (odb *OVNDB) GetLogicalRouters() ([]*LogicalRouter, error) {
-	return odb.imp.GetLogicalRouters()
-}
-
 func (odb *OVNDB) GetLB(name string) ([]*LoadBalancer, error) {
 	return odb.imp.GetLB(name)
 }
 
-func (odb *OVNDB) AddDHCPOptions(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error) {
-	return odb.imp.addDHCPOptionsImp(cidr, options, external_ids)
+func (odb *OVNDB) DHCPOptionsAdd(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error) {
+	return odb.imp.dhcpOptionsAddImp(cidr, options, external_ids)
 }
 
-func (odb *OVNDB) SetDHCPOptions(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error) {
-	return odb.imp.setDHCPOptionsImp(cidr, options, external_ids)
+func (odb *OVNDB) DHCPOptionsSet(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error) {
+	return odb.imp.dhcpOptionsSetImp(cidr, options, external_ids)
 }
 
-func (odb *OVNDB) DelDHCPOptions(uuid string) (*OvnCommand, error) {
-	return odb.imp.delDHCPOptionsImp(uuid)
+func (odb *OVNDB) DHCPOptionsDel(uuid string) (*OvnCommand, error) {
+	return odb.imp.dhcpOptionsDelImp(uuid)
 }
 
-func (odb *OVNDB) GetDHCPOptions() ([]*DHCPOptions, error) {
-	return odb.imp.getDHCPOptionsImp()
+func (odb *OVNDB) DHCPOptionsList() ([]*DHCPOptions, error) {
+	return odb.imp.dhcpOptionsListImp()
 }
 
 func (odb *OVNDB) SetCallBack(callback OVNSignal) {

--- a/qos_test.go
+++ b/qos_test.go
@@ -24,7 +24,7 @@ func TestQoS(t *testing.T) {
 	var cmd *OvnCommand
 	var err error
 
-	cmd, err = ovndbapi.LSWAdd(LSW)
+	cmd, err = ovndbapi.LSAdd(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestQoS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	qosrules, err := ovndbapi.GetQoSBySwitch(LSW)
+	qosrules, err := ovndbapi.QoSList(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestQoS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	qosrules, err = ovndbapi.GetQoSBySwitch(LSW)
+	qosrules, err = ovndbapi.QoSList(LSW)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* change method names to looks like ovn-nbctl
* fix logical switch list to use cache, cleanup unused method from
dhcp_options.

Signed-off-by: Vasiliy Tolstov <v.tolstov@unistack.org>