### PR TITLE
Fix connect string for ssl

### DIFF
--- a/ovn_connect_test.go
+++ b/ovn_connect_test.go
@@ -69,7 +69,7 @@ func TestMain(m *testing.M) {
 			}
 		} else {
 			port, _ := strconv.Atoi(strs[2])
-			cfg.Addr = fmt.Sprintf("tcp:%s%s:%d", strs[0], strs[1], port)
+			cfg.Addr = fmt.Sprintf("%s:%s:%d", strs[0], strs[1], port)
 			api, err = NewClient(cfg)
 			if err != nil {
 				log.Fatal(err)


### PR DESCRIPTION
Current connect string to libovsdb always passes tcp.
Hence, ssl will not work if client wants to use ssl.
This commit fixes the same.