### PR TITLE
Process table updates in the right order when populating cache

### DIFF
--- a/common.go
+++ b/common.go
@@ -49,3 +49,25 @@ const (
 	tableSSL                      string = "SSL"
 	tableGatewayChassis           string = "Gateway_Chassis"
 )
+
+var tablesOrder = []string{
+	tableNBGlobal,
+	tableLogicalSwitchPort,
+	tableAddressSet,
+	tablePortGroup,
+	tableACL,
+	tableQoS,
+	tableMeter,
+	tableMeterBand,
+	tableLogicalRouterPort,
+	tableLogicalRouterStaticRoute,
+	tableNAT,
+	tableDHCPOptions,
+	tableConnection,
+	tableDNS,
+	tableSSL,
+	tableGatewayChassis,
+	tableLogicalSwitch,
+	tableLogicalRouter,
+	tableLoadBalancer,
+}

--- a/ovnnbimp.go
+++ b/ovnnbimp.go
@@ -188,7 +188,12 @@ func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 	odbi.cachemutex.Lock()
 	defer odbi.cachemutex.Unlock()
 
-	for table, tableUpdate := range updates.Updates {
+	for _, table := range tablesOrder {
+		tableUpdate, ok := updates.Updates[table]
+		if !ok {
+			continue
+		}
+
 		if _, ok := odbi.cache[table]; !ok {
 			odbi.cache[table] = make(map[string]libovsdb.Row)
 		}
@@ -229,7 +234,6 @@ func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 						lb, _ := odbi.rowToLB(uuid)
 						odbi.signalCB.OnLoadBalancerCreate(lb)
 					}
-
 				}
 			} else {
 				if odbi.signalCB != nil {


### PR DESCRIPTION
When a logical router update (https://github.com/eBay/go-ovn/blob/84e1e53ffe4fbd63d1b1b4ec3124fae5fb9827cb/ovnnbimp.go#L205) is processed, the `ports` field is considered. If the logical router ports were not processed before, the call to `rowToLogicalRouterPort` (https://github.com/eBay/go-ovn/blob/84e1e53ffe4fbd63d1b1b4ec3124fae5fb9827cb/logical_router.go#L154) will crash as the ports are missing from the cache.

This is because the table updates is a `map[string]TableUpdate`, so there is no guarantee on the tables processing order.