### PR TITLE
update libovsdb version to v0.2.0

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 rm -rf ovs
-git clone --depth 1 https://github.com/openvswitch/ovs.git
+git clone --depth 1 -b branch-2.12 https://github.com/openvswitch/ovs.git
 cd ovs
 ./boot.sh && ./configure --enable-silent-rules
 make -j4


### PR DESCRIPTION
a new tag v0.2.0 has been created in libovsdb project, updating go-ovn
accordingly for better semantic version management.