### PR TITLE
pull ovs/branch-2.12 to test

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 rm -rf ovs
-git clone --depth 1 https://github.com/openvswitch/ovs.git
+git clone --depth 1 -b branch-2.12 https://github.com/openvswitch/ovs.git
 cd ovs
 ./boot.sh && ./configure --enable-silent-rules
 make -j4


### PR DESCRIPTION
due to ovs/ovn split, ovs master doesn't work with go-ovn test,
use branch-2.12 instead.