### PR TITLE
Add function to link switch to router

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,6 +36,8 @@ type Client interface {
 	LSExtIdsAdd(ls string, external_ids map[string]string) (*OvnCommand, error)
 	// Del external_ids from logical_switch
 	LSExtIdsDel(ls string, external_ids map[string]string) (*OvnCommand, error)
+	// Link logical switch to router
+	LinkSwitchToRouter(lsw, lsp, lr, lrp, lrpMac string, networks []string, externalIds map[string]string) (*OvnCommand, error)
 
 	// Add logical port PORT on SWITCH
 	LSPAdd(ls string, lsp string) (*OvnCommand, error)
@@ -224,6 +226,10 @@ func (c *ovndb) LSExtIdsDel(ls string, external_ids map[string]string) (*OvnComm
 
 func (c *ovndb) LSPAdd(ls string, lsp string) (*OvnCommand, error) {
 	return c.lspAddImp(ls, lsp)
+}
+
+func (c *ovndb) LinkSwitchToRouter(lsw, lsp, lr, lrp, lrpMac string, networks []string, externalIds map[string]string) (*OvnCommand, error) {
+	return c.linkSwitchToRouterImp(lsw, lsp, lr, lrp, lrpMac, networks, externalIds)
 }
 
 func (c *ovndb) LSPDel(lsp string) (*OvnCommand, error) {

--- a/logical_switch.go
+++ b/logical_switch.go
@@ -331,3 +331,99 @@ func (odbi *ovndb) lsExtIdsDelImp(ls string, external_ids map[string]string) (*O
 	operations = append(operations, mutateOp)
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
+
+func (odbi *ovndb) linkSwitchToRouterImp(lsw, lsp, lr, lrp, lrpMac string, networks []string, externalIds map[string]string) (*OvnCommand, error) {
+	// validate logical switch
+	row := make(OVNRow)
+	row["name"] = lsw
+	lswUUID := odbi.getRowUUID(tableLogicalSwitch, row)
+	if len(lswUUID) == 0 {
+		return nil, fmt.Errorf("logical switch %s not found", lsw)
+	}
+	// add logical router port
+	strLrpUUID, err := newRowUUID()
+	if err != nil {
+		return nil, err
+	}
+	row = make(OVNRow)
+	row["name"] = lrp
+	row["mac"] = lrpMac
+	// validate
+	if uuid := odbi.getRowUUID(tableLogicalRouterPort, row); len(uuid) > 0 {
+		return nil, fmt.Errorf("logical router port %s already existed", lrp)
+	}
+	networkSet, err := libovsdb.NewOvsSet(networks)
+	if err != nil {
+		return nil, err
+	}
+	row["networks"] = networkSet
+	if externalIds != nil {
+		oMap, err := libovsdb.NewOvsMap(externalIds)
+		if err != nil {
+			return nil, err
+		}
+		row["external_ids"] = oMap
+	}
+	addLrpOp := libovsdb.Operation{
+		Op:       opInsert,
+		Table:    tableLogicalRouterPort,
+		Row:      row,
+		UUIDName: strLrpUUID,
+	}
+
+	// add lrp to lr
+	objLrpUUID := []libovsdb.UUID{stringToGoUUID(strLrpUUID)}
+	lrpSet, err := libovsdb.NewOvsSet(objLrpUUID)
+	if err != nil {
+		return nil, err
+	}
+	lrPortChange := libovsdb.NewMutation("ports", opInsert, lrpSet)
+	lrCondition := libovsdb.NewCondition("name", "==", lr)
+	addLrpToLrOp := libovsdb.Operation{
+		Op:        opMutate,
+		Table:     tableLogicalRouter,
+		Mutations: []interface{}{lrPortChange},
+		Where:     []interface{}{lrCondition},
+	}
+
+	// add logical switch port
+	strLspUUID, err := newRowUUID()
+	if err != nil {
+		return nil, err
+	}
+	port := make(OVNRow)
+	port["name"] = lsp
+	port["type"] = "router"
+	port["addresses"] = "router"
+	options := make(map[string]string)
+	options["router-port"] = lrp
+	optMap, _ := libovsdb.NewOvsMap(options)
+	port["options"] = optMap
+	if uuid := odbi.getRowUUID(tableLogicalSwitchPort, port); len(uuid) > 0 {
+		return nil, ErrorExist
+	}
+	addLspOp := libovsdb.Operation{
+		Op:       opInsert,
+		Table:    tableLogicalSwitchPort,
+		Row:      port,
+		UUIDName: strLspUUID,
+	}
+
+	// add logical switch port to switch
+	objLspUUID := []libovsdb.UUID{stringToGoUUID(strLspUUID)}
+	lspSet, err := libovsdb.NewOvsSet(objLspUUID)
+	if err != nil {
+		return nil, err
+	}
+	lsPortChange := libovsdb.NewMutation("ports", opInsert, lspSet)
+	lsCondition := libovsdb.NewCondition("name", "==", lsw)
+	addLspToLsOp := libovsdb.Operation{
+		Op:        opMutate,
+		Table:     tableLogicalSwitch,
+		Mutations: []interface{}{lsPortChange},
+		Where:     []interface{}{lsCondition},
+	}
+
+	operations := []libovsdb.Operation{addLrpOp, addLrpToLrOp, addLspOp, addLspToLsOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}

--- a/logical_switch_test.go
+++ b/logical_switch_test.go
@@ -28,6 +28,10 @@ const (
 	DUMMY           = "dummy"
 	FOO             = "foo"
 	BAR             = "bar"
+	LS5             = "LS5"
+	LR5             = "LR5"
+	LSP5            = "ls5-lr5"
+	LRP5            = "lr5-ls5"
 )
 
 func TestLSwitchExtIds(t *testing.T) {
@@ -123,4 +127,55 @@ func TestLSwitchExtIds(t *testing.T) {
 		t.Fatalf("err executing command:%v", err)
 	}
 
+}
+
+func TestLinkSwitchToRouter(t *testing.T) {
+	// create Switch
+	t.Logf("Adding %s to OVN", LS5)
+	cmd, err := ovndbapi.LSAdd(LS5)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	cmd, err = ovndbapi.LRAdd(LR5, nil)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	lrpMac := "12:34:56:78:90:ab"
+	cmd, err = ovndbapi.LinkSwitchToRouter(LS5, LSP5, LR5, LRP5, lrpMac, []string{"10.10.10.0/24"}, nil)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	ports, err := ovndbapi.LRPList(LR5)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	found := false
+	for _, port := range ports {
+		if port.Name == LRP5 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("logical router port %s wasn't created", LRP5)
+	}
 }


### PR DESCRIPTION
The function accepts switch name, switch port name, router name, router port
name, router port mac, network and etc, then does following:
1. create router port
2. create switch port
3. add router port to router
4. add switch port to switch

so that the switch will be connected to router.