### PR TITLE
LS Unit tests fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/ebay/go-ovn
 go 1.12
 
 require (
-	github.com/cenkalti/hub v0.0.0-20160527103212-11382a9960d3 // indirect
-	github.com/cenkalti/rpc2 v0.0.0-20170726070524-c51a77e5f664 // indirect
 	github.com/ebay/libovsdb v0.0.0-20190718202342-e49b8c4e1142
 	github.com/google/uuid v1.1.1
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cenk/hub v1.0.0/go.mod h1:rJM1LNAW0ppT8FMMuPK6c2NP/R2nH/UthtuRySSaf6Y=
+github.com/cenkalti/hub v0.0.0-20160527103212-11382a9960d3/go.mod h1:tcYwtS3a2d9NO/0xDXVJWx3IedurUjYCqFCmpi0lpHs=
+github.com/cenkalti/hub v1.0.1-0.20160527103212-11382a9960d3 h1:JoNNeZqjMj74cMtMUi456vOlL/4Kwk1C3sU6e62caJA=
 github.com/cenkalti/hub v1.0.1-0.20160527103212-11382a9960d3/go.mod h1:tcYwtS3a2d9NO/0xDXVJWx3IedurUjYCqFCmpi0lpHs=
 github.com/cenkalti/rpc2 v0.0.0-20170726070524-c51a77e5f664 h1:GqbYbGcGyW6AwuNC+2VbhAePSnKvMhEgHB7Kot9weJU=
 github.com/cenkalti/rpc2 v0.0.0-20170726070524-c51a77e5f664/go.mod h1:v2npkhrXyk5BCnkNIiPdRI23Uq6uWPUQGL2hnRcRr/M=

--- a/logical_switch_test.go
+++ b/logical_switch_test.go
@@ -178,4 +178,28 @@ func TestLinkSwitchToRouter(t *testing.T) {
 	if !found {
 		t.Fatalf("logical router port %s wasn't created", LRP5)
 	}
+	//Cleanup lswitch
+	t.Logf("Remove %s from OVN", LS5)
+	cmd, err = ovndbapi.LSDel(LS5)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	// Cleanup router
+	t.Logf("Remove %s from OVN", LR5)
+	cmd, err = ovndbapi.LRDel(LR5)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
 }


### PR DESCRIPTION
commit f356370 added tests for linking lr to ls.
However, it failed to cleanup the LR and LS. Re-running the test
failed. Hence, this patch cleans up entities that failed to cleanup.