### PR TITLE
SB db chassis and encaps enhancements:

### DIFF
--- a/apis.go
+++ b/apis.go
@@ -76,8 +76,13 @@ type OVNSignal interface {
 	onMeterBandCreate(band *MeterBand)
 	onMeterBandDelete(band *MeterBand)
 
+	// Create/delete chassis from south bound db
 	onChassisCreate(ch *Chassis)
 	onChassisDelete(ch *Chassis)
+
+	// Create/delete encap from south bound db
+	onEncapCreate(ch *Encap)
+	onEncapDelete(ch *Encap)
 }
 
 // OVNNotifier ovnnb and ovnsb notifier

--- a/chassis.go
+++ b/chassis.go
@@ -17,6 +17,7 @@
 package goovn
 
 import (
+	"fmt"
 	"github.com/ebay/libovsdb"
 )
 
@@ -32,66 +33,79 @@ type Chassis struct {
 	VtepLogicalSwitches []string
 }
 
-func (odbi *ovndb) chassisAddImp(name string, hostname string, etype string, ip string) (*OvnCommand, error) {
-	// / Prepare for encap record
-	enCapUUID, err := newRowUUID()
-	if err != nil {
-		return nil, err
+func (odbi *ovndb) chassisAddImp(name string, hostname string, etype []string, ip string,
+	external_ids map[string]string, transport_zones []string, vtep_lswitches []string) (*OvnCommand, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("chassis name cannot be empty")
 	}
-	row := make(OVNRow)
-
-	if len(name) > 0 {
+	if len(etype) == 0 {
+		return nil, fmt.Errorf("chassis encap type cannot be empty")
+	}
+	if len(ip) == 0 {
+		return nil, fmt.Errorf("chassis ip cannot be empty")
+	}
+	//Prepare for encap record
+	var encap_ids [][]string
+	var namedUUID = "named-uuid"
+	var operations []libovsdb.Operation
+	for _, et := range etype {
+		enCapUUID, err := newRowUUID()
+		if err != nil {
+			return nil, err
+		}
+		row := make(OVNRow)
 		row["chassis_name"] = name
-	}
-
-	if len(etype) > 0 {
-		row["type"] = etype
-	}
-
-	if len(ip) > 0 {
+		var encap_id []string
+		encap_id = append(encap_id, namedUUID)
+		encap_id = append(encap_id, enCapUUID)
+		encap_ids = append(encap_ids, encap_id)
 		row["ip"] = ip
-	}
-	if uuid := odbi.getRowUUID(tableEncap, row); len(uuid) > 0 {
-		return nil, ErrorExist
+		row["type"] = et
+		if uuid := odbi.getRowUUID(tableEncap, row); len(uuid) > 0 {
+			return nil, ErrorExist
+		}
+		insertEncapOp := libovsdb.Operation{
+			Op:       opInsert,
+			Table:    tableEncap,
+			Row:      row,
+			UUIDName: enCapUUID,
+		}
+		operations = append(operations, insertEncapOp)
 	}
 
-	insertEncapOp := libovsdb.Operation{
-		Op:       opInsert,
-		Table:    tableEncap,
-		Row:      row,
-		UUIDName: enCapUUID,
-	}
 	// Prepare for chassis record
 	ChassisUUID, err := newRowUUID()
 	if err != nil {
 		return nil, err
 	}
-
 	rowChassis := make(OVNRow)
-
-	var encap_id []string
-	var namedUUID = "named-uuid"
-	encap_id = append(encap_id, namedUUID)
-	encap_id = append(encap_id, enCapUUID)
-
-	rowChassis["encaps"] = encap_id
-	if len(name) > 0 {
-		rowChassis["name"] = name
+	// consolidate encaps
+	var encaps []interface{}
+	encaps = append(encaps, "set")
+	encaps = append(encaps, encap_ids)
+	rowChassis["encaps"] = encaps
+	rowChassis["name"] = name
+	rowChassis["hostname"] = hostname
+	if external_ids != nil {
+		oMap, err := libovsdb.NewOvsMap(external_ids)
+		if err != nil {
+			return nil, err
+		}
+		rowChassis["external_ids"] = oMap
 	}
-	if len(hostname) > 0 {
-		rowChassis["hostname"] = hostname
+	if len(transport_zones) != 0 {
+		rowChassis["transport_zones"] = transport_zones
 	}
-	if uuid := odbi.getRowUUID(tableChassis, row); len(uuid) > 0 {
-		return nil, ErrorExist
+	if len(vtep_lswitches) != 0 {
+		rowChassis["vtep_logical_switches"] = vtep_lswitches
 	}
-
 	insertChassisOp := libovsdb.Operation{
 		Op:       opInsert,
 		Table:    tableChassis,
 		Row:      rowChassis,
 		UUIDName: ChassisUUID,
 	}
-	operations := []libovsdb.Operation{insertEncapOp, insertChassisOp}
+	operations = append(operations, insertChassisOp)
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 
 }
@@ -109,7 +123,7 @@ func (odbi *ovndb) chassisDelImp(name string) (*OvnCommand, error) {
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
-func (odbi *ovndb) chassisGetImp(hostname string) ([]*Chassis, error) {
+func (odbi *ovndb) chassisGetImp(chassis string) ([]*Chassis, error) {
 	var listChassis []*Chassis
 
 	odbi.cachemutex.RLock()
@@ -122,7 +136,14 @@ func (odbi *ovndb) chassisGetImp(hostname string) ([]*Chassis, error) {
 	}
 
 	for uuid, drows := range cacheChassis {
-		if chName, ok := drows.Fields["hostname"].(string); ok && chName == hostname {
+		if chName, ok := drows.Fields["hostname"].(string); ok && chName == chassis {
+			ch, err := odbi.rowToChassis(uuid)
+			if err != nil {
+				return nil, err
+			}
+			listChassis = append(listChassis, ch)
+		}
+		if chName, ok := drows.Fields["name"].(string); ok && chName == chassis {
 			ch, err := odbi.rowToChassis(uuid)
 			if err != nil {
 				return nil, err
@@ -134,12 +155,56 @@ func (odbi *ovndb) chassisGetImp(hostname string) ([]*Chassis, error) {
 }
 
 func (odbi *ovndb) rowToChassis(uuid string) (*Chassis, error) {
+
+	cacheChassis, ok := odbi.cache[tableChassis][uuid]
+	if !ok {
+		return nil, fmt.Errorf("Chassis with uuid%s not found", uuid)
+	}
 	ch := &Chassis{
 		UUID:       uuid,
-		Name:       odbi.cache[tableChassis][uuid].Fields["name"].(string),
-		Hostname:   odbi.cache[tableChassis][uuid].Fields["hostname"].(string),
-		ExternalID: odbi.cache[tableChassis][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
-		NbCfg:      odbi.cache[tableChassis][uuid].Fields["nb_cfg"].(int),
+		Name:       cacheChassis.Fields["name"].(string),
+		Hostname:   cacheChassis.Fields["hostname"].(string),
+		ExternalID: cacheChassis.Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		NbCfg:      cacheChassis.Fields["nb_cfg"].(int),
 	}
+
+	if tz, ok := cacheChassis.Fields["transport_zones"]; ok {
+		switch tz.(type) {
+		case libovsdb.UUID:
+			ch.TransportZones = []string{tz.(libovsdb.UUID).GoUUID}
+		case libovsdb.OvsSet:
+			ch.TransportZones = odbi.ConvertGoSetToStringArray(tz.(libovsdb.OvsSet))
+		}
+	}
+	if vtep, ok := cacheChassis.Fields["vtep_logical_switches"]; ok {
+		switch vtep.(type) {
+		case libovsdb.UUID:
+			ch.VtepLogicalSwitches = []string{vtep.(libovsdb.UUID).GoUUID}
+		case libovsdb.OvsSet:
+			ch.VtepLogicalSwitches = odbi.ConvertGoSetToStringArray(vtep.(libovsdb.OvsSet))
+		}
+	}
+	var encaps []string
+	if enc, ok := cacheChassis.Fields["encaps"]; ok {
+		switch enc.(type) {
+		case libovsdb.UUID:
+			if enuid, ok := enc.(libovsdb.UUID); ok {
+				encaps = append(encaps, enuid.GoUUID)
+			} else {
+				return nil, fmt.Errorf("type libovsdb.UUID casting failed")
+			}
+		case libovsdb.OvsSet:
+			if en, ok := enc.(libovsdb.OvsSet); ok {
+				for _, e := range en.GoSet {
+					if euid, ok := e.(libovsdb.UUID); ok {
+						encaps = append(encaps, euid.GoUUID)
+					}
+				}
+			} else {
+				return nil, fmt.Errorf("type libovsdb.OvsSet casting failed")
+			}
+		}
+	}
+	ch.Encaps = encaps
 	return ch, nil
 }

--- a/client.go
+++ b/client.go
@@ -163,11 +163,15 @@ type Client interface {
 	Execute(cmds ...*OvnCommand) error
 
 	// Add chassis with given name
-	ChassisAdd(name string, hostname string, etype string, ip string) (*OvnCommand, error)
+	ChassisAdd(name string, hostname string, etype []string, ip string, external_ids map[string]string,
+		transport_zones []string, vtep_lswitches []string) (*OvnCommand, error)
 	// Delete chassis with given name
 	ChassisDel(chName string) (*OvnCommand, error)
-	// Get chassis by hostname
-	ChassisGet(chHostname string) ([]*Chassis, error)
+	// Get chassis by hostname or name
+	ChassisGet(chname string) ([]*Chassis, error)
+
+	// Get encaps by chassis name
+	EncapList(chname string) ([]*Encap, error)
 
 	// Close connection to OVN
 	Close() error
@@ -213,12 +217,17 @@ func (c *ovndb) Close() error {
 	return nil
 }
 
-func (c *ovndb) ChassisGet(hostname string) ([]*Chassis, error) {
-	return c.chassisGetImp(hostname)
+func (c *ovndb) EncapList(chname string) ([]*Encap, error) {
+	return c.encapListImp(chname)
 }
 
-func (c *ovndb) ChassisAdd(name string, hostname string, etype string, ip string) (*OvnCommand, error) {
-	return c.chassisAddImp(name, hostname, etype, ip)
+func (c *ovndb) ChassisGet(name string) ([]*Chassis, error) {
+	return c.chassisGetImp(name)
+}
+
+func (c *ovndb) ChassisAdd(name string, hostname string, etype []string, ip string,
+	external_ids map[string]string, transport_zones []string, vtep_lswitches []string) (*OvnCommand, error) {
+	return c.chassisAddImp(name, hostname, etype, ip, external_ids, transport_zones, vtep_lswitches)
 }
 
 func (c *ovndb) ChassisDel(name string) (*OvnCommand, error) {

--- a/encap.go
+++ b/encap.go
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2020 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package goovn
+
+import (
+	"fmt"
+	"github.com/ebay/libovsdb"
+)
+
+// Encap table OVN SB
+type Encap struct {
+	UUID        string
+	ChassisName string
+	Ip          string
+	Options     map[interface{}]interface{}
+	Encaptype   string
+}
+
+func (odbi *ovndb) encapListImp(chassisName string) ([]*Encap, error) {
+
+	odbi.cachemutex.RLock()
+	defer odbi.cachemutex.RUnlock()
+
+	cacheChassis, ok := odbi.cache[tableChassis]
+	if !ok {
+		return nil, ErrorNotFound
+	}
+
+	var encaps []*Encap
+	for _, drows := range cacheChassis {
+		if ch, ok := drows.Fields["name"].(string); ok && ch == chassisName {
+			if enc, ok := drows.Fields["encaps"]; ok {
+				switch enc.(type) {
+				case libovsdb.UUID:
+					if enuid, ok := enc.(libovsdb.UUID); ok {
+						cenc, err := odbi.rowToEncap(enuid.GoUUID)
+						if err != nil {
+							return nil, err
+						}
+						encaps = append(encaps, cenc)
+					} else {
+						return nil, fmt.Errorf("type libovsdb.UUID casting failed")
+					}
+				case libovsdb.OvsSet:
+					if en, ok := enc.(libovsdb.OvsSet); ok {
+						for _, e := range en.GoSet {
+							if euid, ok := e.(libovsdb.UUID); ok {
+								enc, err := odbi.rowToEncap(euid.GoUUID)
+								if err != nil {
+									return nil, err
+								}
+								encaps = append(encaps, enc)
+							}
+						}
+					} else {
+						return nil, fmt.Errorf("type libovsdb.OvsSet casting failed")
+					}
+				}
+			}
+		}
+	}
+	return encaps, nil
+
+}
+
+func (odbi *ovndb) rowToEncap(uuid string) (*Encap, error) {
+	cacheEncaps, ok := odbi.cache[tableEncap][uuid]
+	if !ok {
+		return nil, fmt.Errorf("Encap with uuid%s not found", uuid)
+	}
+	en := &Encap{
+		UUID:        uuid,
+		ChassisName: cacheEncaps.Fields["chassis_name"].(string),
+		Ip:          cacheEncaps.Fields["ip"].(string),
+		Options:     cacheEncaps.Fields["options"].(libovsdb.OvsMap).GoMap,
+		Encaptype:   cacheEncaps.Fields["type"].(string),
+	}
+	return en, nil
+}

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -249,6 +249,9 @@ func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 					case tableChassis:
 						chassis, _ := odbi.rowToChassis(uuid)
 						odbi.signalCB.onChassisCreate(chassis)
+					case tableEncap:
+						encap, _ := odbi.rowToEncap(uuid)
+						odbi.signalCB.onEncapCreate(encap)
 					}
 				}
 			} else {
@@ -293,6 +296,9 @@ func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 						case tableChassis:
 							chassis, _ := odbi.rowToChassis(uuid)
 							odbi.signalCB.onChassisDelete(chassis)
+						case tableEncap:
+							encap, _ := odbi.rowToEncap(uuid)
+							odbi.signalCB.onEncapDelete(encap)
 						}
 					}(table, uuid)
 				}


### PR DESCRIPTION
Current code only supports one encap for a chassis.
Hence, add support for adding one or many encaps for the chassis.

e.g. ovn-sbctl chassis-add ch1 stt,geneve,vxlan 1.2.3.5