### PR TITLE
Refactor client, api and UTs:

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -105,14 +105,12 @@ The backup database file is sandbox/${db}2.db
 }
 
 ovn_start_db nb standalone 1 $srcdir/ovn/ovn-nb.ovsschema
+ovn_start_db sb standalone 1 $srcdir/ovn/ovn-sb.ovsschema
 export GO111MODULE=on
 cd ../
 go get -v ./...
 go test -v
 
-# Run ovn sb db tests
-ovn_start_db sb standalone 1 $srcdir/ovn/ovn-sb.ovsschema
-go test -v
 
 pkill ovsdb-server
 rm -rf ovs

--- a/acl_test.go
+++ b/acl_test.go
@@ -23,10 +23,7 @@ import (
 )
 
 func TestACLs(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running acl test against sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	var cmds []*OvnCommand
 	var cmd *OvnCommand
 	var err error

--- a/address_set_test.go
+++ b/address_set_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var ovndbapi Client
+
 func findAS(name string) bool {
 	as, err := ovndbapi.ASList()
 	if err != nil {
@@ -61,10 +63,7 @@ func addressSetCmp(asname string, targetvalue []string) bool {
 }
 
 func TestAddressSet(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running addressset test againts sb db")
-	}
+	ovndbapi = getOVNClient(dbNB)
 	addressList := []string{"127.0.0.1"}
 	var cmd *OvnCommand
 	var err error

--- a/chassis_encap_test.go
+++ b/chassis_encap_test.go
@@ -23,10 +23,7 @@ import (
 )
 
 func TestEncaps(t *testing.T) {
-	db = getOVNDB()
-	if db == dbNB {
-		t.Skip("Skip running chassis test against nb db")
-	}
+	ovndbapi := getOVNClient(dbSB)
 	t.Logf("Adding Chassis to OVN SB DB")
 	ocmd, err := ovndbapi.ChassisAdd(CHASSIS_NAME, CHASSIS_HOSTNAME, ENCAP_TYPES, IP, nil, nil, nil)
 	if err != nil {

--- a/chassis_test.go
+++ b/chassis_test.go
@@ -30,10 +30,7 @@ const (
 var ENCAP_TYPES = []string{"stt", "geneve", "vxlan"}
 
 func TestChassis(t *testing.T) {
-	db = getOVNDB()
-	if db == dbNB {
-		t.Skip("Skip running chassis test against nb db")
-	}
+	ovndbapi := getOVNClient(dbSB)
 	t.Logf("Adding Chassis to OVN SB DB")
 	ocmd, err := ovndbapi.ChassisAdd(CHASSIS_NAME, CHASSIS_HOSTNAME, ENCAP_TYPES, IP, nil, nil, nil)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -20,8 +20,9 @@ import (
 	"crypto/tls"
 )
 
-// Config ovnnb client config
+// Config ovn nb and sb db client config
 type Config struct {
+	db           string
 	Addr         string
 	TLSConfig    *tls.Config
 	SignalCB     OVNSignal

--- a/dhcp_options_test.go
+++ b/dhcp_options_test.go
@@ -29,10 +29,7 @@ const (
 )
 
 func TestDHCPOptions(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running dhcp test againts sb db")
-	}
+	ovndbapi := getOVNClient("")
 	var cmds []*OvnCommand
 	var cmd *OvnCommand
 	var err error

--- a/examples/main.go
+++ b/examples/main.go
@@ -38,8 +38,7 @@ func init() {
 	if ovs_rundir == "" {
 		ovs_rundir = ovsRundir
 	}
-	ovndbapi, err = goovn.NewClient(&goovn.Config{Addr: "unix:" + ovs_rundir + "/" + ovnnbSocket},
-	"OVN_Northbound")
+	ovndbapi, err = goovn.NewClient(&goovn.Config{Addr: "unix:" + ovs_rundir + "/" + ovnnbSocket})
 	if err != nil {
 		panic(err)
 	}

--- a/load_balancer_test.go
+++ b/load_balancer_test.go
@@ -23,10 +23,7 @@ import (
 const LB1 = "lb1"
 
 func TestLoadBalancer(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running LB test againts sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	t.Logf("Adding LB to OVN")
 	ocmd, err := ovndbapi.LBAdd(LB1, "192.168.0.19:80", "tcp", []string{"10.0.0.11:80", "10.0.0.12:80"})
 	if err != nil {

--- a/logical_router_load_balancer_test.go
+++ b/logical_router_load_balancer_test.go
@@ -28,10 +28,7 @@ const (
 )
 
 func TestLRLoadBalancer(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running lr lb test againts sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	// Add LR
 	cmd, err := ovndbapi.LRAdd(LR1, nil)
 	if err != nil {

--- a/logical_router_port_test.go
+++ b/logical_router_port_test.go
@@ -5,10 +5,7 @@ import "testing"
 const LR4 = "lr4"
 
 func TestLogicalRouterPort(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running lr port test againts sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	var cmds []*OvnCommand
 	var cmd *OvnCommand
 	var err error

--- a/logical_router_static_route_test.go
+++ b/logical_router_static_route_test.go
@@ -13,10 +13,7 @@ const (
 )
 
 func TestLogicalRouterStaticRoute(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running lr static route test againts sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	cmd, err := ovndbapi.LRAdd(LR2, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/logical_router_test.go
+++ b/logical_router_test.go
@@ -8,10 +8,7 @@ import (
 const LB4 = "lb4"
 
 func TestLogicalRouter(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running lr test againts sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	var cmds []*OvnCommand
 	var cmd *OvnCommand
 	var err error

--- a/logical_switch_load_balancer_test.go
+++ b/logical_switch_load_balancer_test.go
@@ -28,10 +28,7 @@ const (
 )
 
 func TestLSLoadBalancer(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running ls lb test againts sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	// create Switch
 	t.Logf("Adding  %s to OVN", LSW1)
 	cmd, err := ovndbapi.LSAdd(LSW1)

--- a/logical_switch_test.go
+++ b/logical_switch_test.go
@@ -35,10 +35,7 @@ const (
 )
 
 func TestLSwitchExtIds(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running ls extid test againts sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	// create Switch
 	t.Logf("Adding  %s to OVN", LS3)
 	cmd, err := ovndbapi.LSAdd(LS3)
@@ -134,9 +131,7 @@ func TestLSwitchExtIds(t *testing.T) {
 }
 
 func TestLinkSwitchToRouter(t *testing.T) {
-	if db == dbSB {
-		t.Skip("Skip running link ls to lr test againts sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	// create Switch
 	t.Logf("Adding %s to OVN", LS5)
 	cmd, err := ovndbapi.LSAdd(LS5)

--- a/meter_test.go
+++ b/meter_test.go
@@ -11,10 +11,7 @@ const (
 )
 
 func TestMeter(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running meter test againts sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	var cmds []*OvnCommand
 	cmd, err := ovndbapi.MeterAdd(METER1, "drop", 101, "kbps", nil, 300)
 	if err != nil {

--- a/nat_test.go
+++ b/nat_test.go
@@ -7,10 +7,7 @@ import (
 const LR3 = "lr3"
 
 func TestNAT(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running meter test againts sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	var cmd *OvnCommand
 	var err error
 	defer func() {

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -171,7 +171,7 @@ func (odbi *ovndb) execute(cmds ...*OvnCommand) error {
 		}
 	}
 
-	_, err := odbi.transact(db, ops...)
+	_, err := odbi.transact(odbi.db, ops...)
 	if err != nil {
 		return err
 	}

--- a/qos_test.go
+++ b/qos_test.go
@@ -23,10 +23,7 @@ import (
 const LSW3 = "TEST_LSW3"
 
 func TestQoS(t *testing.T) {
-	db = getOVNDB()
-	if db == dbSB {
-		t.Skip("Skip running qos test againts sb db")
-	}
+	ovndbapi := getOVNClient(dbNB)
 	var cmd *OvnCommand
 	var err error
 


### PR DESCRIPTION
1. Each UT should use its own client
2. Handle client interface to default to nb db if no db
   is passed to ensure old client interface is backward
   compatible.
3. Fix CI to run all UTs accordingly.