### PR TITLE
Make db as exportable

### DIFF
--- a/client.go
+++ b/client.go
@@ -187,7 +187,7 @@ type ovndb struct {
 }
 
 func NewClient(cfg *Config) (Client, error) {
-	db := cfg.db
+	db := cfg.Db
 	// db string should strictly be OVN_Northbound or OVN_Southbound
 	if db == "" {
 		// default to OVN_Northbound

--- a/config.go
+++ b/config.go
@@ -22,7 +22,7 @@ import (
 
 // Config ovn nb and sb db client config
 type Config struct {
-	db           string
+	Db           string
 	Addr         string
 	TLSConfig    *tls.Config
 	SignalCB     OVNSignal

--- a/test_common.go
+++ b/test_common.go
@@ -62,7 +62,7 @@ func getOVNClient(db string) (ovndbapi Client) {
 		ovn_socket = OVNSB_SOCKET
 	}
 
-	cfg.db = db
+	cfg.Db = db
 	var ovs_rundir = os.Getenv("OVS_RUNDIR")
 	if ovs_rundir == "" {
 		ovs_rundir = OVS_RUNDIR


### PR DESCRIPTION
Since new clients can now specify where they want to connect to,
either nb db or sb db, make db identifier as exportable so that
when used in other packages, it can be available to use as is.