### PR TITLE
Make DB constants as exportable

### DIFF
--- a/acl_test.go
+++ b/acl_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestACLs(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	var cmds []*OvnCommand
 	var cmd *OvnCommand
 	var err error

--- a/address_set_test.go
+++ b/address_set_test.go
@@ -63,7 +63,7 @@ func addressSetCmp(asname string, targetvalue []string) bool {
 }
 
 func TestAddressSet(t *testing.T) {
-	ovndbapi = getOVNClient(dbNB)
+	ovndbapi = getOVNClient(DBNB)
 	addressList := []string{"127.0.0.1"}
 	var cmd *OvnCommand
 	var err error

--- a/chassis_encap_test.go
+++ b/chassis_encap_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestEncaps(t *testing.T) {
-	ovndbapi := getOVNClient(dbSB)
+	ovndbapi := getOVNClient(DBSB)
 	t.Logf("Adding Chassis to OVN SB DB")
 	ocmd, err := ovndbapi.ChassisAdd(CHASSIS_NAME, CHASSIS_HOSTNAME, ENCAP_TYPES, IP, nil, nil, nil)
 	if err != nil {

--- a/chassis_test.go
+++ b/chassis_test.go
@@ -30,7 +30,7 @@ const (
 var ENCAP_TYPES = []string{"stt", "geneve", "vxlan"}
 
 func TestChassis(t *testing.T) {
-	ovndbapi := getOVNClient(dbSB)
+	ovndbapi := getOVNClient(DBSB)
 	t.Logf("Adding Chassis to OVN SB DB")
 	ocmd, err := ovndbapi.ChassisAdd(CHASSIS_NAME, CHASSIS_HOSTNAME, ENCAP_TYPES, IP, nil, nil, nil)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -191,9 +191,9 @@ func NewClient(cfg *Config) (Client, error) {
 	// db string should strictly be OVN_Northbound or OVN_Southbound
 	if db == "" {
 		// default to OVN_Northbound
-		db = dbNB
-	} else if !(db == dbNB || db == dbSB) {
-		return nil, fmt.Errorf("Valid db names are: %s and %s", dbNB, dbSB)
+		db = DBNB
+	} else if !(db == DBNB || db == DBSB) {
+		return nil, fmt.Errorf("Valid db names are: %s and %s", DBNB, DBSB)
 	}
 
 	imp := &ovndb{

--- a/common.go
+++ b/common.go
@@ -25,8 +25,8 @@ const (
 )
 
 const (
-	dbNB string = "OVN_Northbound"
-	dbSB string = "OVN_Southbound"
+	DBNB string = "OVN_Northbound"
+	DBSB string = "OVN_Southbound"
 )
 
 const (

--- a/load_balancer_test.go
+++ b/load_balancer_test.go
@@ -23,7 +23,7 @@ import (
 const LB1 = "lb1"
 
 func TestLoadBalancer(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	t.Logf("Adding LB to OVN")
 	ocmd, err := ovndbapi.LBAdd(LB1, "192.168.0.19:80", "tcp", []string{"10.0.0.11:80", "10.0.0.12:80"})
 	if err != nil {

--- a/logical_router_load_balancer_test.go
+++ b/logical_router_load_balancer_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 func TestLRLoadBalancer(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	// Add LR
 	cmd, err := ovndbapi.LRAdd(LR1, nil)
 	if err != nil {

--- a/logical_router_port_test.go
+++ b/logical_router_port_test.go
@@ -5,7 +5,7 @@ import "testing"
 const LR4 = "lr4"
 
 func TestLogicalRouterPort(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	var cmds []*OvnCommand
 	var cmd *OvnCommand
 	var err error

--- a/logical_router_static_route_test.go
+++ b/logical_router_static_route_test.go
@@ -13,7 +13,7 @@ const (
 )
 
 func TestLogicalRouterStaticRoute(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	cmd, err := ovndbapi.LRAdd(LR2, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/logical_router_test.go
+++ b/logical_router_test.go
@@ -8,7 +8,7 @@ import (
 const LB4 = "lb4"
 
 func TestLogicalRouter(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	var cmds []*OvnCommand
 	var cmd *OvnCommand
 	var err error

--- a/logical_switch_load_balancer_test.go
+++ b/logical_switch_load_balancer_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 func TestLSLoadBalancer(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	// create Switch
 	t.Logf("Adding  %s to OVN", LSW1)
 	cmd, err := ovndbapi.LSAdd(LSW1)

--- a/logical_switch_test.go
+++ b/logical_switch_test.go
@@ -35,7 +35,7 @@ const (
 )
 
 func TestLSwitchExtIds(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	// create Switch
 	t.Logf("Adding  %s to OVN", LS3)
 	cmd, err := ovndbapi.LSAdd(LS3)
@@ -131,7 +131,7 @@ func TestLSwitchExtIds(t *testing.T) {
 }
 
 func TestLinkSwitchToRouter(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	// create Switch
 	t.Logf("Adding %s to OVN", LS5)
 	cmd, err := ovndbapi.LSAdd(LS5)

--- a/meter_test.go
+++ b/meter_test.go
@@ -11,7 +11,7 @@ const (
 )
 
 func TestMeter(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	var cmds []*OvnCommand
 	cmd, err := ovndbapi.MeterAdd(METER1, "drop", 101, "kbps", nil, 300)
 	if err != nil {

--- a/nat_test.go
+++ b/nat_test.go
@@ -7,7 +7,7 @@ import (
 const LR3 = "lr3"
 
 func TestNAT(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	var cmd *OvnCommand
 	var err error
 	defer func() {

--- a/qos_test.go
+++ b/qos_test.go
@@ -23,7 +23,7 @@ import (
 const LSW3 = "TEST_LSW3"
 
 func TestQoS(t *testing.T) {
-	ovndbapi := getOVNClient(dbNB)
+	ovndbapi := getOVNClient(DBNB)
 	var cmd *OvnCommand
 	var err error
 

--- a/test_common.go
+++ b/test_common.go
@@ -54,7 +54,7 @@ func getOVNClient(db string) (ovndbapi Client) {
 	var api Client
 	var err error
 	cfg := &Config{}
-	if db == dbNB || db == "" {
+	if db == DBNB || db == "" {
 		ovn_db = os.Getenv("OVN_NB_DB")
 		ovn_socket = OVNNB_SOCKET
 	} else {


### PR DESCRIPTION
Since clients specify either nb or sb db, client can re-use the constants
from go-ovn directly.
Hence, renaming dbNB as dbSB to make those identifiers explortable.