### PR TITLE
Fix lr static route client error

### DIFF
--- a/logical_router_static_route.go
+++ b/logical_router_static_route.go
@@ -18,7 +18,6 @@ package goovn
 
 import (
 	"fmt"
-
 	"github.com/ebay/libovsdb"
 )
 
@@ -157,7 +156,7 @@ func (odbi *ovndb) lrsrListImp(lr string) ([]*LogicalRouterStaticRoute, error) {
 	if !ok {
 		return nil, ErrorNotFound
 	}
-
+	var lrFound bool
 	for _, drows := range cacheLogicalRouter {
 		if rlr, ok := drows.Fields["name"].(string); ok && rlr == lr {
 			staticRoutes := drows.Fields["static_routes"]
@@ -185,8 +184,13 @@ func (odbi *ovndb) lrsrListImp(lr string) ([]*LogicalRouterStaticRoute, error) {
 					return nil, fmt.Errorf("Unsupport type found in ovsdb rows")
 				}
 			}
+			lrFound = true
 			break
 		}
+	}
+
+	if !lrFound {
+		return nil, ErrorNotFound
 	}
 	return listLRSR, nil
 }

--- a/logical_router_static_route_test.go
+++ b/logical_router_static_route_test.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	LR2      = "lr2"
-	IPPREFIX = "10.0.0.1/24"
-	NEXTHOP  = "10.3.0.1"
+	LR2          = "lr2"
+	IPPREFIX     = "10.0.0.1/24"
+	NEXTHOP      = "10.3.0.1"
+	FAKENOROUTER = "fakenorouter"
 )
 
 func TestLogicalRouterStaticRoute(t *testing.T) {
@@ -94,4 +95,9 @@ func TestLogicalRouterStaticRoute(t *testing.T) {
 		t.Fatalf("lr not deleted %v", lrs)
 	}
 
+	// verify static route list for non-existing routers
+	lrsr, err = ovndbapi.LRSRList(FAKENOROUTER)
+	if err != nil {
+		assert.EqualError(t, ErrorNotFound, err.Error())
+	}
 }


### PR DESCRIPTION
When listing static routes for a logical router, ensure router exist in ovn.
Current code returns empty static routes list without any error.
Hence, this commit fixes it.