### PR TITLE
Improvise error handling if object does not exist.

### DIFF
--- a/acl.go
+++ b/acl.go
@@ -309,7 +309,7 @@ func (odbi *ovndb) aclListImp(lsw string) ([]*ACL, error) {
 	if !ok {
 		return nil, ErrorNotFound
 	}
-
+	var lsFound bool
 	for _, drows := range cacheLogicalSwitch {
 		if rlsw, ok := drows.Fields["name"].(string); ok && rlsw == lsw {
 			acls := drows.Fields["acls"]
@@ -331,8 +331,12 @@ func (odbi *ovndb) aclListImp(lsw string) ([]*ACL, error) {
 					}
 				}
 			}
+			lsFound = true
 			break
 		}
+	}
+	if !lsFound {
+		return nil, ErrorNotFound
 	}
 	return listACL, nil
 }

--- a/acl_test.go
+++ b/acl_test.go
@@ -250,4 +250,9 @@ func TestACLs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// verify ACL list for non-existing switch
+	_, err = ovndbapi.ACLList(FAKENOSWITCH)
+	if err != nil {
+		assert.EqualError(t, ErrorNotFound, err.Error())
+	}
 }

--- a/chassis_encap_test.go
+++ b/chassis_encap_test.go
@@ -85,4 +85,10 @@ func TestEncaps(t *testing.T) {
 		t.Fatalf("error: Chassis deletion not done, total:%v", len(chassis))
 	}
 	t.Logf("Chassis %s deleted", chName)
+
+	// verify encap list for non-existing chassis
+	_, err = ovndbapi.EncapList(FAKENOCHASSIS)
+	if err != nil {
+		assert.EqualError(t, ErrorNotFound, err.Error())
+	}
 }

--- a/encap.go
+++ b/encap.go
@@ -41,6 +41,7 @@ func (odbi *ovndb) encapListImp(chassisName string) ([]*Encap, error) {
 	}
 
 	var encaps []*Encap
+	var chFound bool
 	for _, drows := range cacheChassis {
 		if ch, ok := drows.Fields["name"].(string); ok && ch == chassisName {
 			if enc, ok := drows.Fields["encaps"]; ok {
@@ -71,7 +72,12 @@ func (odbi *ovndb) encapListImp(chassisName string) ([]*Encap, error) {
 					}
 				}
 			}
+			chFound = true
+			break
 		}
+	}
+	if !chFound {
+		return nil, ErrorNotFound
 	}
 	return encaps, nil
 

--- a/logical_router.go
+++ b/logical_router.go
@@ -304,7 +304,7 @@ func (odbi *ovndb) lrlbListImp(lr string) ([]*LoadBalancer, error) {
 	if !ok {
 		return nil, ErrorSchema
 	}
-
+	var lrFound bool
 	for _, drows := range cacheLogicalRouter {
 		if router, ok := drows.Fields["name"].(string); ok && router == lr {
 			lbs := drows.Fields["load_balancer"]
@@ -338,8 +338,12 @@ func (odbi *ovndb) lrlbListImp(lr string) ([]*LoadBalancer, error) {
 					return nil, fmt.Errorf("Unsupport type found in ovsdb rows")
 				}
 			}
+			lrFound = true
 			break
 		}
+	}
+	if !lrFound {
+		return nil, ErrorNotFound
 	}
 	return listLB, nil
 }

--- a/logical_router_load_balancer_test.go
+++ b/logical_router_load_balancer_test.go
@@ -87,7 +87,7 @@ func TestLRLoadBalancer(t *testing.T) {
 	}
 	t.Logf("Deleting LB lb2 to LRouter %s Done", LR1)
 	// verify lb delete from lr
-	lbs, err = ovndbapi.LRLBList(LB2)
+	lbs, err = ovndbapi.LRLBList(LR1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,4 +120,10 @@ func TestLRLoadBalancer(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("Router %s deleted", LR1)
+
+	// verify lb list for non-existing routers
+	_, err = ovndbapi.LRLBList(FAKENOROUTER)
+	if err != nil {
+		assert.EqualError(t, ErrorNotFound, err.Error())
+	}
 }

--- a/logical_router_port.go
+++ b/logical_router_port.go
@@ -193,6 +193,7 @@ func (odbi *ovndb) lrpListImp(lr string) ([]*LogicalRouterPort, error) {
 		return nil, ErrorNotFound
 	}
 
+	var lrFound bool
 	for _, drows := range cacheLogicalRouter {
 		if rlr, ok := drows.Fields["name"].(string); ok && rlr == lr {
 			ports := drows.Fields["ports"]
@@ -220,8 +221,12 @@ func (odbi *ovndb) lrpListImp(lr string) ([]*LogicalRouterPort, error) {
 					return nil, fmt.Errorf("Unsupport type found in ovsdb rows")
 				}
 			}
+			lrFound = true
 			break
 		}
+	}
+	if !lrFound {
+		return nil, ErrorNotFound
 	}
 	return listLRP, nil
 }

--- a/logical_router_port_test.go
+++ b/logical_router_port_test.go
@@ -1,6 +1,9 @@
 package goovn
 
-import "testing"
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 const LR4 = "lr4"
 
@@ -89,4 +92,9 @@ func TestLogicalRouterPort(t *testing.T) {
 		t.Logf("Successfully deleted router %s", LR4)
 	}
 
+	// verify router port list for non-existing routers
+	_, err = ovndbapi.LRPList(FAKENOROUTER)
+	if err != nil {
+		assert.EqualError(t, ErrorNotFound, err.Error())
+	}
 }

--- a/logical_router_static_route_test.go
+++ b/logical_router_static_route_test.go
@@ -7,10 +7,9 @@ import (
 )
 
 const (
-	LR2          = "lr2"
-	IPPREFIX     = "10.0.0.1/24"
-	NEXTHOP      = "10.3.0.1"
-	FAKENOROUTER = "fakenorouter"
+	LR2      = "lr2"
+	IPPREFIX = "10.0.0.1/24"
+	NEXTHOP  = "10.3.0.1"
 )
 
 func TestLogicalRouterStaticRoute(t *testing.T) {

--- a/logical_router_test.go
+++ b/logical_router_test.go
@@ -132,7 +132,7 @@ func TestLogicalRouter(t *testing.T) {
 	}
 	t.Logf("Deleting LB lb2 to LRouter %s Done", LR)
 	// verify lb delete from lr
-	lbs, err := ovndbapi.LRLBList(LB4)
+	lbs, err := ovndbapi.LRLBList(LR)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/logical_switch.go
+++ b/logical_switch.go
@@ -238,7 +238,7 @@ func (odbi *ovndb) lslbListImp(lswitch string) ([]*LoadBalancer, error) {
 	if !ok {
 		return nil, ErrorSchema
 	}
-
+	var lsFound bool
 	for _, drows := range cacheLogicalSwitch {
 		if rlsw, ok := drows.Fields["name"].(string); ok && rlsw == lswitch {
 			lbs := drows.Fields["load_balancer"]
@@ -272,8 +272,12 @@ func (odbi *ovndb) lslbListImp(lswitch string) ([]*LoadBalancer, error) {
 					return nil, fmt.Errorf("Unsupport type found in ovsdb rows")
 				}
 			}
+			lsFound = true
 			break
 		}
+	}
+	if !lsFound {
+		return nil, ErrorNotFound
 	}
 	return listLB, nil
 }

--- a/logical_switch_load_balancer_test.go
+++ b/logical_switch_load_balancer_test.go
@@ -115,4 +115,9 @@ func TestLSLoadBalancer(t *testing.T) {
 		t.Fatalf("err executing command:%v", err)
 	}
 
+	// verify LB list for non-existing switch
+	_, err = ovndbapi.LSLBList(FAKENOSWITCH)
+	if err != nil {
+		assert.EqualError(t, ErrorNotFound, err.Error())
+	}
 }

--- a/logical_switch_port.go
+++ b/logical_switch_port.go
@@ -289,7 +289,7 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 	if !ok {
 		return nil, ErrorSchema
 	}
-
+	var lsFound bool
 	for _, drows := range cacheLogicalSwitch {
 		if rlsw, ok := drows.Fields["name"].(string); ok && rlsw == lsw {
 			ports := drows.Fields["ports"]
@@ -317,8 +317,12 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 					return nil, fmt.Errorf("Unsupport type found in ovsdb rows")
 				}
 			}
+			lsFound = true
 			break
 		}
+	}
+	if !lsFound {
+		return nil, ErrorNotFound
 	}
 	return listLSP, nil
 }

--- a/logical_switch_test.go
+++ b/logical_switch_test.go
@@ -204,4 +204,10 @@ func TestLinkSwitchToRouter(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
+
+	// verify logical port list for non-existing switch
+	_, err = ovndbapi.LSPList(FAKENOSWITCH)
+	if err != nil {
+		assert.EqualError(t, ErrorNotFound, err.Error())
+	}
 }

--- a/qos.go
+++ b/qos.go
@@ -182,7 +182,7 @@ func (odbi *ovndb) qosListImp(ls string) ([]*QoS, error) {
 	if !ok {
 		return nil, ErrorNotFound
 	}
-
+	var lsFound bool
 	for _, drows := range cacheLogicalSwitch {
 		if rlsw, ok := drows.Fields["name"].(string); ok && rlsw == ls {
 			qosrules := drows.Fields["qos_rules"]
@@ -210,8 +210,12 @@ func (odbi *ovndb) qosListImp(ls string) ([]*QoS, error) {
 					return nil, fmt.Errorf("Unsupport type found in ovsdb rows")
 				}
 			}
+			lsFound = true
 			break
 		}
+	}
+	if !lsFound {
+		return nil, ErrorNotFound
 	}
 	return listQoS, nil
 }

--- a/qos_test.go
+++ b/qos_test.go
@@ -17,6 +17,7 @@
 package goovn
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -105,5 +106,11 @@ func TestQoS(t *testing.T) {
 	err = ovndbapi.Execute(cmd)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// verify QOS list for non-existing switch
+	_, err = ovndbapi.QoSList(FAKENOSWITCH)
+	if err != nil {
+		assert.EqualError(t, ErrorNotFound, err.Error())
 	}
 }

--- a/test_common.go
+++ b/test_common.go
@@ -43,6 +43,9 @@ const (
 	SKIP_TLS_VERIFY      = true
 	SSL                  = "ssl"
 	UNIX                 = "unix"
+	FAKENOCHASSIS        = "fakenochassis"
+	FAKENOSWITCH         = "fakenoswitch"
+	FAKENOROUTER         = "fakenorouter"
 )
 
 var (


### PR DESCRIPTION
e.g when listing logical router ports, return error if router is not
present in ovn.
Similarly fix for rest entities like load balancer list, ls port list,
qos, acl, encaps, etc.

This is already being handled in ovn-nb/sbctl clients in ovn. Hence,
handling the same here.