### PR TITLE
Fix missing parameters of execution function of OvnCommand

### DIFF
--- a/apis.go
+++ b/apis.go
@@ -29,7 +29,7 @@ type OvnCommand struct {
 
 // Execute sends command to ovnnb
 func (ocmd *OvnCommand) Execute() error {
-	return ocmd.Exe.Execute()
+	return ocmd.Exe.Execute(ocmd)
 }
 
 // Execution executes multiple ovnnb commands

--- a/client.go
+++ b/client.go
@@ -176,6 +176,8 @@ type Client interface {
 	Close() error
 }
 
+var _ Client = &ovndb{}
+
 type ovndb struct {
 	client       *libovsdb.OvsdbClient
 	cache        map[string]map[string]libovsdb.Row

--- a/examples/main.go
+++ b/examples/main.go
@@ -46,10 +46,14 @@ func init() {
 
 func main() {
 
+	// execute a ovnCommand by either of the following two methods :
+	// 1) ovndbapi.Execute(specificCommand)
+	// 2) specificCommand.Execute()
+
 	ocmd, _ := ovndbapi.LSAdd("ls1")
 	ovndbapi.Execute(ocmd)
 	ocmd, _ = ovndbapi.LSPAdd("ls1", "test")
-	ovndbapi.Execute(ocmd)
+	ocmd.Execute()
 	ocmd, _ = ovndbapi.LSPSetAddress("test", "12:34:56:78:90 10.10.10.1")
 	ovndbapi.Execute(ocmd)
 


### PR DESCRIPTION
# add the missing parameters, so we can execute ovnCommand directly.

Before:
---
ocmd, _ := ovndbapi.LSAdd("ls1")
ovndbapi.Execute(ocmd)

After:
---
ocmd, _ := ovndbapi.LSAdd("ls1")
ocmd.Execute()