### PR TITLE
Support for LSPGet API in the client interface as well as configuration of LSP fields

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,8 +18,9 @@ package goovn
 
 import (
 	"fmt"
-	"github.com/ebay/libovsdb"
 	"sync"
+
+	"github.com/ebay/libovsdb"
 )
 
 // Client ovnnb/sb client
@@ -40,6 +41,8 @@ type Client interface {
 	// Link logical switch to router
 	LinkSwitchToRouter(lsw, lsp, lr, lrp, lrpMac string, networks []string, externalIds map[string]string) (*OvnCommand, error)
 
+	// Get logical switch port by name
+	LSPGet(lsp string) (*LogicalSwitchPort, error)
 	// Add logical port PORT on SWITCH
 	LSPAdd(ls string, lsp string) (*OvnCommand, error)
 	// Delete PORT from its attached switch
@@ -266,6 +269,10 @@ func (c *ovndb) LSExtIdsAdd(ls string, external_ids map[string]string) (*OvnComm
 
 func (c *ovndb) LSExtIdsDel(ls string, external_ids map[string]string) (*OvnCommand, error) {
 	return c.lsExtIdsDelImp(ls, external_ids)
+}
+
+func (c *ovndb) LSPGet(lsp string) (*LogicalSwitchPort, error) {
+	return c.lspGetImp(lsp)
 }
 
 func (c *ovndb) LSPAdd(ls string, lsp string) (*OvnCommand, error) {

--- a/client.go
+++ b/client.go
@@ -128,7 +128,10 @@ type Client interface {
 	LSPGetDHCPv6Options(lsp string) (*DHCPOptions, error)
 	// Set options in LSP
 	LSPSetOptions(lsp string, options map[string]string) (*OvnCommand, error)
-
+	// Set dynamic addresses in LSP
+	LSPSetDynamicAddresses(lsp string, address string) (*OvnCommand, error)
+	// Get dynamic addresses from LSP
+	LSPGetDynamicAddresses(lsp string) (string, error)
 	// Add dhcp options for cidr and provided external_ids
 	DHCPOptionsAdd(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error)
 	// Set dhcp options and set external_ids for specific uuid
@@ -313,6 +316,14 @@ func (c *ovndb) LSPGetDHCPv6Options(lsp string) (*DHCPOptions, error) {
 
 func (c *ovndb) LSPSetOptions(lsp string, options map[string]string) (*OvnCommand, error) {
 	return c.lspSetOptionsImp(lsp, options)
+}
+
+func (c *ovndb) LSPSetDynamicAddresses(lsp string, address string) (*OvnCommand, error) {
+	return c.lspSetDynamicAddressesImp(lsp, address)
+}
+
+func (c *ovndb) LSPGetDynamicAddresses(lsp string) (string, error) {
+	return c.lspGetDynamicAddressesImp(lsp)
 }
 
 func (c *ovndb) LSLBAdd(ls string, lb string) (*OvnCommand, error) {

--- a/client.go
+++ b/client.go
@@ -132,6 +132,10 @@ type Client interface {
 	LSPSetDynamicAddresses(lsp string, address string) (*OvnCommand, error)
 	// Get dynamic addresses from LSP
 	LSPGetDynamicAddresses(lsp string) (string, error)
+	// Set external_ids for LSP
+	LSPSetExternalIds(lsp string, external_ids map[string]string) (*OvnCommand, error)
+	// Get external_ids from LSP
+	LSPGetExternalIds(lsp string) (map[string]string, error)
 	// Add dhcp options for cidr and provided external_ids
 	DHCPOptionsAdd(cidr string, options map[string]string, external_ids map[string]string) (*OvnCommand, error)
 	// Set dhcp options and set external_ids for specific uuid
@@ -324,6 +328,14 @@ func (c *ovndb) LSPSetDynamicAddresses(lsp string, address string) (*OvnCommand,
 
 func (c *ovndb) LSPGetDynamicAddresses(lsp string) (string, error) {
 	return c.lspGetDynamicAddressesImp(lsp)
+}
+
+func (c *ovndb) LSPSetExternalIds(lsp string, external_ids map[string]string) (*OvnCommand, error) {
+	return c.lspSetExternalIdsImp(lsp, external_ids)
+}
+
+func (c *ovndb) LSPGetExternalIds(lsp string) (map[string]string, error) {
+	return c.lspGetExternalIdsImp(lsp)
 }
 
 func (c *ovndb) LSLBAdd(ls string, lb string) (*OvnCommand, error) {

--- a/logical_switch_port_test.go
+++ b/logical_switch_port_test.go
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2019 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package goovn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	PORT_TEST_LS1          = "LogicalSwitch1"
+	PORT_TEST_LSP1         = "LogicalSwitchPort1"
+	PORT_TEST_LSP2         = "LogicalSwitchPort2"
+	PORT_TEST_LSP1DYNADDR1 = "a.b.c.d"
+	PORT_TEST_LSP2DYNADDR2 = ""
+)
+
+func TestLogicalSwitchPortAPI(t *testing.T) {
+	ovndbapi := getOVNClient(DBNB)
+	// create Switch
+	t.Logf("Adding  %s to OVN", PORT_TEST_LS1)
+	cmd, err := ovndbapi.LSAdd(PORT_TEST_LS1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ls, err := ovndbapi.LSGet(PORT_TEST_LS1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ls[0].Name != PORT_TEST_LS1 {
+		t.Fatalf("ls not created %v", PORT_TEST_LS1)
+	}
+
+	// create logical switch port 1
+	cmd, err = ovndbapi.LSPAdd(PORT_TEST_LS1, PORT_TEST_LSP1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create logical switch port 2
+	cmd, err = ovndbapi.LSPAdd(PORT_TEST_LS1, PORT_TEST_LSP2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// test LSPGet API
+	lsp1, err := ovndbapi.LSPGet(PORT_TEST_LSP1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, lsp1.Name, PORT_TEST_LSP1)
+
+	//check for set/get dynamic addresses with non-empty string
+	cmd, err = ovndbapi.LSPSetDynamicAddresses(PORT_TEST_LSP1, PORT_TEST_LSP1DYNADDR1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure the cache now shows the updated lsp object
+	lsp1, err = ovndbapi.LSPGet(PORT_TEST_LSP1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, lsp1.DynamicAddresses, PORT_TEST_LSP1DYNADDR1)
+
+	dynAddr1, err := ovndbapi.LSPGetDynamicAddresses(PORT_TEST_LSP1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, dynAddr1, PORT_TEST_LSP1DYNADDR1)
+
+	//check for Set/Get Dynamic Address with empty string
+	cmd, err = ovndbapi.LSPSetDynamicAddresses(PORT_TEST_LSP2, PORT_TEST_LSP2DYNADDR2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lsp2, err := ovndbapi.LSPGet(PORT_TEST_LSP2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, lsp2.DynamicAddresses, PORT_TEST_LSP2DYNADDR2)
+
+}


### PR DESCRIPTION
This pull request adds support for 

1) the LSPGet API in the client's interface. The implementation is already present, but the API was not being exposed.

2) dynamic address configuration for the logical switch port.

3) support for configuration of external ids on the logical switch port.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>