### PR TITLE
Remove spurious dynamic address type assertion

### DIFF
--- a/logical_switch_port.go
+++ b/logical_switch_port.go
@@ -331,7 +331,6 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) *LogicalSwitchPort {
 		default:
 			//	glog.V(OVNLOGLEVEL).Info("Unsupport type found in lport dynamic address.")
 		}
-		lp.DynamicAddresses = dynamicAddresses.(string)
 	}
 
 	return lp

--- a/logical_switch_port.go
+++ b/logical_switch_port.go
@@ -271,7 +271,7 @@ func (odbi *ovndb) lspGetExternalIdsImp(lsp string) (map[string]string, error) {
 	return extIds, nil
 }
 
-func (odbi *ovndb) rowToLogicalPort(uuid string) *LogicalSwitchPort {
+func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 	lp := &LogicalSwitchPort{
 		UUID:       uuid,
 		Name:       odbi.cache[tableLogicalSwitchPort][uuid].Fields["name"].(string),
@@ -303,7 +303,7 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) *LogicalSwitchPort {
 		case libovsdb.OvsSet:
 			lp.Addresses = odbi.ConvertGoSetToStringArray(addr.(libovsdb.OvsSet))
 		default:
-			//	glog.V(OVNLOGLEVEL).Info("Unsupport type found in lport address.")
+			return nil, fmt.Errorf("Unsupported type found in lport address.")
 		}
 	}
 
@@ -314,7 +314,7 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) *LogicalSwitchPort {
 		case libovsdb.OvsSet:
 			lp.PortSecurity = odbi.ConvertGoSetToStringArray(portsecurity.(libovsdb.OvsSet))
 		default:
-			//glog.V(OVNLOGLEVEL).Info("Unsupport type found in lport port security.")
+			return nil, fmt.Errorf("Unsupported type found in port security.")
 		}
 	}
 
@@ -329,11 +329,11 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) *LogicalSwitchPort {
 		case libovsdb.OvsSet:
 			lp.DynamicAddresses = strings.Join(odbi.ConvertGoSetToStringArray(dynamicAddresses.(libovsdb.OvsSet)), " ")
 		default:
-			//	glog.V(OVNLOGLEVEL).Info("Unsupport type found in lport dynamic address.")
+			return nil, fmt.Errorf("Unsupport type found in lport dynamic address.")
 		}
 	}
 
-	return lp
+	return lp, nil
 }
 
 // Get lsp by name
@@ -348,7 +348,7 @@ func (odbi *ovndb) lspGetImp(lsp string) (*LogicalSwitchPort, error) {
 
 	for uuid, drows := range cacheLogicalSwitchPort {
 		if rlsp, ok := drows.Fields["name"].(string); ok && rlsp == lsp {
-			return odbi.rowToLogicalPort(uuid), nil
+			return odbi.rowToLogicalPort(uuid)
 		}
 	}
 	return nil, ErrorNotFound
@@ -375,7 +375,10 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 					if ps, ok := ports.(libovsdb.OvsSet); ok {
 						for _, p := range ps.GoSet {
 							if vp, ok := p.(libovsdb.UUID); ok {
-								tp := odbi.rowToLogicalPort(vp.GoUUID)
+								tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+								if err != nil {
+									return nil, fmt.Errorf("Failed to get logical port: %s", err)
+								}
 								listLSP = append(listLSP, tp)
 							}
 						}
@@ -384,13 +387,16 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 					}
 				case libovsdb.UUID:
 					if vp, ok := ports.(libovsdb.UUID); ok {
-						tp := odbi.rowToLogicalPort(vp.GoUUID)
+						tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+						if err != nil {
+							return nil, fmt.Errorf("Failed to get logical port: %s", err)
+						}
 						listLSP = append(listLSP, tp)
 					} else {
 						return nil, fmt.Errorf("type libovsdb.UUID casting failed")
 					}
 				default:
-					return nil, fmt.Errorf("Unsupport type found in ovsdb rows")
+					return nil, fmt.Errorf("Unsupported type found in ovsdb rows")
 				}
 			}
 			lsFound = true

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -226,8 +226,10 @@ func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 						ls := odbi.rowToLogicalSwitch(uuid)
 						odbi.signalCB.OnLogicalSwitchCreate(ls)
 					case tableLogicalSwitchPort:
-						lp := odbi.rowToLogicalPort(uuid)
-						odbi.signalCB.OnLogicalPortCreate(lp)
+						lp, err := odbi.rowToLogicalPort(uuid)
+						if err == nil {
+							odbi.signalCB.OnLogicalPortCreate(lp)
+						}
 					case tableACL:
 						acl := odbi.rowToACL(uuid)
 						odbi.signalCB.OnACLCreate(acl)
@@ -273,8 +275,10 @@ func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 							ls := odbi.rowToLogicalSwitch(uuid)
 							odbi.signalCB.OnLogicalSwitchDelete(ls)
 						case tableLogicalSwitchPort:
-							lp := odbi.rowToLogicalPort(uuid)
-							odbi.signalCB.OnLogicalPortDelete(lp)
+							lp, err := odbi.rowToLogicalPort(uuid)
+							if err == nil {
+								odbi.signalCB.OnLogicalPortDelete(lp)
+							}
 						case tableACL:
 							acl := odbi.rowToACL(uuid)
 							odbi.signalCB.OnACLDelete(acl)

--- a/port_group.go
+++ b/port_group.go
@@ -152,7 +152,10 @@ func (odbi *ovndb) GetLogicalPortsByPortGroup(group string) ([]*LogicalSwitchPor
 					if ps, ok := ports.(libovsdb.OvsSet); ok {
 						for _, p := range ps.GoSet {
 							if vp, ok := p.(libovsdb.UUID); ok {
-								tp := odbi.rowToLogicalPort(vp.GoUUID)
+								tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+								if err != nil {
+									return nil, fmt.Errorf("Couldn't get logical port: %s", err)
+								}
 								listLSP = append(listLSP, tp)
 							}
 						}
@@ -161,7 +164,10 @@ func (odbi *ovndb) GetLogicalPortsByPortGroup(group string) ([]*LogicalSwitchPor
 					}
 				case libovsdb.UUID:
 					if vp, ok := ports.(libovsdb.UUID); ok {
-						tp := odbi.rowToLogicalPort(vp.GoUUID)
+						tp, err := odbi.rowToLogicalPort(vp.GoUUID)
+						if err != nil {
+							return nil, fmt.Errorf("Couldn't get logical port: %s", err)
+						}
 						listLSP = append(listLSP, tp)
 					} else {
 						return nil, fmt.Errorf("type libovsdb.UUID casting failed")


### PR DESCRIPTION
There was a left-over type assertion after changes were made to do a switch for the contained type of the interface. This commit fixes that.