### PR TITLE
Add api support for NB/SB Global tables and fix the LSP APIs for options and external ids.

### DIFF
--- a/client.go
+++ b/client.go
@@ -182,6 +182,18 @@ type Client interface {
 	// Get encaps by chassis name
 	EncapList(chname string) ([]*Encap, error)
 
+	// Set NB_Global table options
+	NBGlobalSetOptions(options map[string]string) (*OvnCommand, error)
+
+	// Get NB_Global table options
+	NBGlobalGetOptions() (map[string]string, error)
+
+	// Set SB_Global table options
+	SBGlobalSetOptions(options map[string]string) (*OvnCommand, error)
+
+	// Get SB_Global table options
+	SBGlobalGetOptions() (map[string]string, error)
+
 	// Close connection to OVN
 	Close() error
 }
@@ -520,4 +532,38 @@ func (c *ovndb) MeterList() ([]*Meter, error) {
 
 func (c *ovndb) MeterBandsList() ([]*MeterBand, error) {
 	return c.meterBandsListImp()
+}
+
+func (c *ovndb) NBGlobalSetOptions(options map[string]string) (*OvnCommand, error) {
+	return c.nbGlobalSetOptionsImp(options)
+}
+
+func (c *ovndb) NBGlobalGetOptions() (map[string]string, error) {
+	return c.nbGlobalGetOptionsImp()
+}
+
+func (c *ovndb) SBGlobalSetOptions(options map[string]string) (*OvnCommand, error) {
+	return c.sbGlobalSetOptionsImp(options)
+}
+
+func (c *ovndb) SBGlobalGetOptions() (map[string]string, error) {
+	return c.sbGlobalGetOptionsImp()
+}
+
+// these functions are helpers for unit-tests, but not part of the API
+
+func (c *ovndb) nbGlobalAdd(options map[string]string) (*OvnCommand, error) {
+	return c.nbGlobalAddImp(options)
+}
+
+func (c *ovndb) nbGlobalDel() (*OvnCommand, error) {
+	return c.nbGlobalDelImp()
+}
+
+func (c *ovndb) sbGlobalAdd(options map[string]string) (*OvnCommand, error) {
+	return c.sbGlobalAddImp(options)
+}
+
+func (c *ovndb) sbGlobalDel() (*OvnCommand, error) {
+	return c.sbGlobalDelImp()
 }

--- a/client.go
+++ b/client.go
@@ -128,6 +128,8 @@ type Client interface {
 	LSPGetDHCPv6Options(lsp string) (*DHCPOptions, error)
 	// Set options in LSP
 	LSPSetOptions(lsp string, options map[string]string) (*OvnCommand, error)
+	// Get options from LSP
+	LSPGetOptions(lsp string) (map[string]string, error)
 	// Set dynamic addresses in LSP
 	LSPSetDynamicAddresses(lsp string, address string) (*OvnCommand, error)
 	// Get dynamic addresses from LSP
@@ -332,6 +334,10 @@ func (c *ovndb) LSPGetDHCPv6Options(lsp string) (*DHCPOptions, error) {
 
 func (c *ovndb) LSPSetOptions(lsp string, options map[string]string) (*OvnCommand, error) {
 	return c.lspSetOptionsImp(lsp, options)
+}
+
+func (c *ovndb) LSPGetOptions(lsp string) (map[string]string, error) {
+	return c.lspGetOptionsImp(lsp)
 }
 
 func (c *ovndb) LSPSetDynamicAddresses(lsp string, address string) (*OvnCommand, error) {

--- a/common.go
+++ b/common.go
@@ -51,6 +51,7 @@ const (
 	tableGatewayChassis           string = "Gateway_Chassis"
 	tableChassis                  string = "Chassis"
 	tableEncap                    string = "Encap"
+	tableSBGlobal                 string = "SB_Global"
 )
 
 var tablesOrder = []string{
@@ -75,4 +76,5 @@ var tablesOrder = []string{
 	tableLogicalRouter,
 	tableChassis,
 	tableEncap,
+	tableSBGlobal,
 }

--- a/global_common.go
+++ b/global_common.go
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2020 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package goovn
+
+import (
+	"fmt"
+
+	"github.com/ebay/libovsdb"
+)
+
+func (odbi *ovndb) addGlobalTableRowImp(options map[string]string, table string) (*OvnCommand, error) {
+	namedUUID, err := newRowUUID()
+	if err != nil {
+		return nil, err
+	}
+	row := make(OVNRow)
+
+	optionsMap, err := libovsdb.NewOvsMap(options)
+
+	if err != nil {
+		return nil, err
+	}
+
+	row["options"] = optionsMap
+
+	if uuid := odbi.getRowUUID(table, row); len(uuid) > 0 {
+		return nil, ErrorExist
+	}
+
+	insertOp := libovsdb.Operation{
+		Op:       opInsert,
+		Table:    table,
+		Row:      row,
+		UUIDName: namedUUID,
+	}
+
+	operations := []libovsdb.Operation{insertOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
+func (odbi *ovndb) delGlobalTableRowImp(table string) (*OvnCommand, error) {
+	if table == "" {
+		return nil, fmt.Errorf("Invalid table name passed to delete")
+	}
+
+	uuid, err := func() (string, error) {
+		odbi.cachemutex.RLock()
+		defer odbi.cachemutex.RUnlock()
+		cacheGlobal, ok := odbi.cache[table]
+		if !ok {
+			return "", fmt.Errorf("Table %s not found in cache %v", table, odbi.cache)
+		}
+		for uuid, _ := range cacheGlobal {
+			return uuid, nil
+		}
+		return "", fmt.Errorf("No row found in %s table", table)
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	condition := libovsdb.NewCondition("_uuid", "==", stringToGoUUID(uuid))
+	deleteOp := libovsdb.Operation{
+		Op:    opDelete,
+		Table: table,
+		Where: []interface{}{condition},
+	}
+	operations := []libovsdb.Operation{deleteOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
+func (odbi *ovndb) globalSetOptionsImp(options map[string]string, table string) (*OvnCommand, error) {
+	if options == nil || table == "" {
+		return nil, fmt.Errorf("Invalid arguments passed to set options: table: %s, options:  %v", table, options)
+	}
+	optionsMap, err := libovsdb.NewOvsMap(options)
+	if err != nil {
+		return nil, err
+	}
+
+	uuid, err := func() (string, error) {
+		odbi.cachemutex.RLock()
+		defer odbi.cachemutex.RUnlock()
+		cacheGlobal, ok := odbi.cache[table]
+		if !ok {
+			return "", fmt.Errorf("Table %s not found in cache %v", table, odbi.cache)
+		}
+		for uuid, _ := range cacheGlobal {
+			return uuid, nil
+		}
+		return "", fmt.Errorf("No row found in %s table", table)
+	}()
+	if err != nil {
+		return nil, err
+	}
+	row := make(OVNRow)
+	row["options"] = optionsMap
+	condition := libovsdb.NewCondition("_uuid", "==", stringToGoUUID(uuid))
+
+	// simple mutate operation
+	updateOp := libovsdb.Operation{
+		Op:    opUpdate,
+		Table: table,
+		Row:   row,
+		Where: []interface{}{condition},
+	}
+	operations := []libovsdb.Operation{updateOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
+func (odbi *ovndb) globalGetOptionsImp(table string) (map[string]string, error) {
+	odbi.cachemutex.RLock()
+	defer odbi.cachemutex.RUnlock()
+	cacheGlobal, ok := odbi.cache[table]
+	if !ok {
+		return nil, ErrorSchema
+	}
+	for _, drows := range cacheGlobal {
+		if options, ok := drows.Fields["options"]; ok {
+			switch options.(type) {
+			case libovsdb.OvsMap:
+				optionsGoMap := options.(libovsdb.OvsMap).GoMap
+				optionsMap := make(map[string]string)
+				for k, v := range optionsGoMap {
+					key, keyOk := k.(string)
+					value, valueOk := v.(string)
+					if !keyOk || !valueOk {
+						continue
+					}
+					optionsMap[key] = value
+				}
+				return optionsMap, nil
+			default:
+				return nil, fmt.Errorf("Error getting options field of the %s table - unsupported type", table)
+			}
+		}
+	}
+	return nil, fmt.Errorf("No row found in %s table", table)
+}

--- a/logical_switch_port_test.go
+++ b/logical_switch_port_test.go
@@ -31,6 +31,14 @@ const (
 	PORT_TEST_LSP2DYNADDR2   = ""
 	PORT_TEST_EXT_ID_MAC_KEY = "mac_addr"
 	PORT_TEST_EXT_ID_MAC     = "00:01:02:03:04:05"
+	PORT_TEST_EXT_ID_MAC_2   = "01:02:03:05:05:06"
+	PORT_TEST_EXT_ID_IP_KEY  = "ip_addr"
+	PORT_TEST_EXT_ID_IP      = "169.254.1.1"
+	PORT_TEST_OPT_1_KEY      = "foo1"
+	PORT_TEST_OPT_1_VAL      = "bar1"
+	PORT_TEST_OPT_1_VAL_2    = "baz1"
+	PORT_TEST_OPT_2_KEY      = "foo2"
+	PORT_TEST_OPT_2_VAL      = "bar2"
 )
 
 func TestLogicalSwitchPortAPI(t *testing.T) {
@@ -123,10 +131,13 @@ func TestLogicalSwitchPortAPI(t *testing.T) {
 	}
 	assert.Equal(t, lsp2.DynamicAddresses, PORT_TEST_LSP2DYNADDR2)
 
+	// test external id APIs
 	extIds, err := ovndbapi.LSPGetExternalIds(PORT_TEST_LSP1)
 	assert.Equal(t, extIds != nil, true)
 
+	t.Logf("Setting external ids with two keys")
 	extIds[PORT_TEST_EXT_ID_MAC_KEY] = PORT_TEST_EXT_ID_MAC
+	extIds[PORT_TEST_EXT_ID_IP_KEY] = PORT_TEST_EXT_ID_IP
 
 	cmd, err = ovndbapi.LSPSetExternalIds(PORT_TEST_LSP1, extIds)
 	if err != nil {
@@ -136,7 +147,7 @@ func TestLogicalSwitchPortAPI(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	t.Logf("Validating the external ids are set correctly")
 	extIdsRet, err := ovndbapi.LSPGetExternalIds(PORT_TEST_LSP1)
 	if err != nil {
 		t.Fatal(err)
@@ -147,13 +158,119 @@ func TestLogicalSwitchPortAPI(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, extIdMac, PORT_TEST_EXT_ID_MAC)
 
+	extIdIP, ok := extIdsRet[PORT_TEST_EXT_ID_IP_KEY]
+	assert.Equal(t, ok, true)
+	assert.Equal(t, extIdIP, PORT_TEST_EXT_ID_IP)
+
+	t.Logf("Validated the external ids are set correctly")
+	// update one of the existing keys, remove one key
+	// and make sure it's a complete update.
+	t.Logf("Validating that keys get clobbered by Set API correctly")
+	extIds[PORT_TEST_EXT_ID_MAC_KEY] = PORT_TEST_EXT_ID_MAC_2
+	delete(extIds, PORT_TEST_EXT_ID_IP_KEY)
+	t.Logf("Remove one of the external ids and verify the contents")
+	cmd, err = ovndbapi.LSPSetExternalIds(PORT_TEST_LSP1, extIds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	extIdsRet, err = ovndbapi.LSPGetExternalIds(PORT_TEST_LSP1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Validating that only the MAC key is present in the external ids")
+	extIdMac, ok = extIdsRet[PORT_TEST_EXT_ID_MAC_KEY]
+
+	assert.Equal(t, ok, true)
+	assert.Equal(t, extIdMac, PORT_TEST_EXT_ID_MAC_2)
+
+	t.Logf("Validated that the MAC key's value has updated in the external ids")
+
+	// make sure IP key is not present in external ids
+	extIdIP, ok = extIdsRet[PORT_TEST_EXT_ID_IP_KEY]
+	assert.Equal(t, !ok, true)
+
+	t.Logf("Validated that the IP key is not present in the external ids")
+
+	// test options API
+	options, err := ovndbapi.LSPGetOptions(PORT_TEST_LSP1)
+	assert.Equal(t, options != nil, true)
+
+	t.Logf("Validating the options are set correctly")
+
+	options[PORT_TEST_OPT_1_KEY] = PORT_TEST_OPT_1_VAL
+	options[PORT_TEST_OPT_2_KEY] = PORT_TEST_OPT_2_VAL
+
+	cmd, err = ovndbapi.LSPSetOptions(PORT_TEST_LSP1, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	optionsRet, err := ovndbapi.LSPGetOptions(PORT_TEST_LSP1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	option1, ok := optionsRet[PORT_TEST_OPT_1_KEY]
+
+	assert.Equal(t, ok, true)
+	assert.Equal(t, option1, PORT_TEST_OPT_1_VAL)
+
+	option2, ok := optionsRet[PORT_TEST_OPT_2_KEY]
+	assert.Equal(t, ok, true)
+	assert.Equal(t, option2, PORT_TEST_OPT_2_VAL)
+
+	t.Logf("Validated that multiple options are set correctly")
+
+	// update one of the existing keys, remove one key
+	// and make sure it's a complete update.
+	t.Logf("Validating that keys get clobbered by Set API correctly")
+
+	options[PORT_TEST_OPT_1_KEY] = PORT_TEST_OPT_1_VAL_2
+	delete(options, PORT_TEST_OPT_2_KEY)
+	t.Logf("Remove one of the options and verify the contents")
+
+	cmd, err = ovndbapi.LSPSetOptions(PORT_TEST_LSP1, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	optionsRet, err = ovndbapi.LSPGetOptions(PORT_TEST_LSP1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Validating that only the OPT_1 key is present in the options")
+
+	option1, ok = optionsRet[PORT_TEST_OPT_1_KEY]
+
+	assert.Equal(t, ok, true)
+	assert.Equal(t, option1, PORT_TEST_OPT_1_VAL_2)
+	t.Logf("Validated that the OPT_1 key's value has updated in the options")
+
+	// make sure IP key is not present in external ids
+	option2, ok = optionsRet[PORT_TEST_OPT_2_KEY]
+	assert.Equal(t, !ok, true)
+	t.Logf("Validated that the OPT_2 key is not present in the options")
+
 	//validate that setting fields on an empty LSP string gives a nil cmd and an error
 	cmd, err = ovndbapi.LSPSetDynamicAddresses(PORT_TEST_LSP3, PORT_TEST_LSP1DYNADDR1)
-	assert.Equal(t, cmd, nil)
+	assert.Equal(t, cmd == nil, true)
 	assert.Equal(t, err == nil, false)
 
 	cmd, err = ovndbapi.LSPSetExternalIds(PORT_TEST_LSP3, extIds)
-	assert.Equal(t, cmd, nil)
+	assert.Equal(t, cmd == nil, true)
 	assert.Equal(t, err == nil, false)
 
 	cmd, err = ovndbapi.LSDel(PORT_TEST_LS1)

--- a/nb_global.go
+++ b/nb_global.go
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2020 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package goovn
+
+type NBGlobalTableRow struct {
+	UUID        string
+	Options     map[interface{}]interface{}
+	ExternalID  map[interface{}]interface{}
+	Connections []string
+	SSL         string
+	IPSec       bool
+}
+
+func (odbi *ovndb) nbGlobalAddImp(options map[string]string) (*OvnCommand, error) {
+	return odbi.addGlobalTableRowImp(options, tableNBGlobal)
+}
+
+func (odbi *ovndb) nbGlobalDelImp() (*OvnCommand, error) {
+	return odbi.delGlobalTableRowImp(tableNBGlobal)
+}
+
+// ovsdb-client -v transact '["Open_vSwitch", {"op" : "update", "table" : "NB_Global", "where": [["_uuid", "==", ["uuid", "587c6ee2-93f9-4bd8-9794-f4a983d139a4"]]],
+// "row":{ "options" : [ "map", [[ "bar", "baz"],["engine_test", "engine-foo"]]],}}]'
+
+func (odbi *ovndb) nbGlobalSetOptionsImp(options map[string]string) (*OvnCommand, error) {
+	return odbi.globalSetOptionsImp(options, tableNBGlobal)
+}
+
+func (odbi *ovndb) nbGlobalGetOptionsImp() (map[string]string, error) {
+	return odbi.globalGetOptionsImp(tableNBGlobal)
+}

--- a/nb_global_test.go
+++ b/nb_global_test.go
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2020 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package goovn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	NB_GLOBAL_OPTIONS_1_KEY = "controller-test-key"
+	NB_GLOBAL_OPTIONS_1_VAL = "controller-test-val"
+	NB_GLOBAL_DUMMY_OPT_KEY = "foo"
+	NB_GLOBAL_DUMMY_OPT_VAL = "587c6ee2-93f9-4bd8-9794-f4a983d139a4"
+)
+
+func TestNBGlobalAPI(t *testing.T) {
+	ovndbapi := getOVNClient(DBNB)
+	t.Logf("Adding row to NB_Global table in OVN")
+	options := make(map[string]string)
+	options[NB_GLOBAL_DUMMY_OPT_KEY] = NB_GLOBAL_DUMMY_OPT_VAL
+	ovn, ok := ovndbapi.(*ovndb)
+	if !ok {
+		t.Fatal(fmt.Errorf("Invalid type assertion"))
+	}
+	cmd, err := ovn.nbGlobalAdd(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Set options and verify
+	options, err = ovndbapi.NBGlobalGetOptions()
+	assert.Equal(t, options != nil, true)
+	options[NB_GLOBAL_OPTIONS_1_KEY] = NB_GLOBAL_OPTIONS_1_VAL
+	cmd, err = ovndbapi.NBGlobalSetOptions(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	//verify the options are set
+	options, err = ovndbapi.NBGlobalGetOptions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	val, ok := options[NB_GLOBAL_OPTIONS_1_KEY]
+	assert.Equal(t, ok, true)
+	assert.Equal(t, val, NB_GLOBAL_OPTIONS_1_VAL)
+
+	t.Logf("Deleting row from NB_Global table in OVN")
+	cmd, err = ovn.nbGlobalDel()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	assert.Equal(t, err == nil, true)
+}

--- a/sb_global.go
+++ b/sb_global.go
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2020 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package goovn
+
+type SBGlobalTableRow struct {
+	UUID        string
+	Options     map[interface{}]interface{}
+	ExternalID  map[interface{}]interface{}
+	Connections []string
+	SSL         string
+	IPSec       bool
+}
+
+func (odbi *ovndb) sbGlobalAddImp(options map[string]string) (*OvnCommand, error) {
+	return odbi.addGlobalTableRowImp(options, tableSBGlobal)
+}
+
+func (odbi *ovndb) sbGlobalDelImp() (*OvnCommand, error) {
+	return odbi.delGlobalTableRowImp(tableSBGlobal)
+}
+
+// ovsdb-client -v transact '["Open_vSwitch", {"op" : "update", "table" : "SB_Global", "where": [["_uuid", "==", ["uuid", "587c6ee2-93f9-4bd8-9794-f4a983d139a4"]]],
+// "row":{ "options" : [ "map", [[ "bar", "baz"],["engine_test", "engine-foo"]]],}}]'
+
+func (odbi *ovndb) sbGlobalSetOptionsImp(options map[string]string) (*OvnCommand, error) {
+	return odbi.globalSetOptionsImp(options, tableSBGlobal)
+}
+
+func (odbi *ovndb) sbGlobalGetOptionsImp() (map[string]string, error) {
+	return odbi.globalGetOptionsImp(tableSBGlobal)
+}

--- a/sb_global_test.go
+++ b/sb_global_test.go
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2020 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package goovn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	SB_GLOBAL_OPTIONS_1_KEY = "controller-test-key"
+	SB_GLOBAL_OPTIONS_1_VAL = "controller-test-val"
+	SB_GLOBAL_DUMMY_OPT_KEY = "foo"
+	SB_GLOBAL_DUMMY_OPT_VAL = "587c6ee2-93f9-4bd8-9794-f4a983d139a4"
+)
+
+func TestSBGlobalAPI(t *testing.T) {
+	ovndbapi := getOVNClient(DBSB)
+	t.Logf("Adding row to SB_Global table in OVN")
+	options := make(map[string]string)
+	options[SB_GLOBAL_DUMMY_OPT_KEY] = SB_GLOBAL_DUMMY_OPT_VAL
+
+	ovn, ok := ovndbapi.(*ovndb)
+	if !ok {
+		t.Fatal(fmt.Errorf("Invalid type assertion"))
+	}
+
+	cmd, err := ovn.sbGlobalAdd(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Logf("Got an error while adding row to the sb_global table: %s", err)
+		t.Fatal(err)
+	}
+
+	//Set options and verify
+	options, err = ovndbapi.SBGlobalGetOptions()
+	assert.Equal(t, options != nil, true)
+	options[SB_GLOBAL_OPTIONS_1_KEY] = SB_GLOBAL_OPTIONS_1_VAL
+	cmd, err = ovndbapi.SBGlobalSetOptions(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	//verify the options are set
+	options, err = ovndbapi.SBGlobalGetOptions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	val, ok := options[SB_GLOBAL_OPTIONS_1_KEY]
+	assert.Equal(t, ok, true)
+	assert.Equal(t, val, SB_GLOBAL_OPTIONS_1_VAL)
+
+	t.Logf("Deleting row from SB_Global table in OVN")
+	cmd, err = ovn.sbGlobalDel()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	assert.Equal(t, err == nil, true)
+}


### PR DESCRIPTION
This commit adds support for creating and deleting NB/SB rows via the go-api as also the ability to set options on the rows. In reality the add/delete rows is only used for unit-testing since ovn-northd is the one that creates the rows during start up in the NB_Global table.

There was also a bug in the way the LSP SetOptions and SetExternalIds api worked. Updating entries in these maps would fail since instead of calling an `opUpdate` on the entire row, these APIs were trying to mutate options/external-ids using individual key-values using `opInsert`. That would have failed unless there is a delete first followed by an insert. 

