### PR TITLE
Call reconnect in deferred manner instead of inline with disconnect

### DIFF
--- a/ovnnotify.go
+++ b/ovnnotify.go
@@ -36,7 +36,7 @@ func (notify ovnNotifier) Echo([]interface{}) {
 
 func (notify ovnNotifier) Disconnected(client *libovsdb.OvsdbClient) {
 	if notify.odbi.reconn {
-		notify.odbi.reconnect()
+		defer notify.odbi.reconnect()
 	} else if notify.odbi.disconnectCB != nil {
 		notify.odbi.disconnectCB()
 	}


### PR DESCRIPTION
Make sure that the reconnect call is deferred instead of inline with the disconnect call back.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>