### PR TITLE
Fix addresses format from slice to string

### DIFF
--- a/logical_switch_port.go
+++ b/logical_switch_port.go
@@ -115,11 +115,7 @@ func (odbi *ovndb) lspDelImp(lsp string) (*OvnCommand, error) {
 
 func (odbi *ovndb) lspSetAddressImp(lsp string, addr ...string) (*OvnCommand, error) {
 	row := make(OVNRow)
-	addresses, err := libovsdb.NewOvsSet(addr)
-	if err != nil {
-		return nil, err
-	}
-	row["addresses"] = addresses
+	row["addresses"] = strings.Join(addr, " ")
 	condition := libovsdb.NewCondition("name", "==", lsp)
 	updateOp := libovsdb.Operation{
 		Op:    opUpdate,
@@ -133,11 +129,7 @@ func (odbi *ovndb) lspSetAddressImp(lsp string, addr ...string) (*OvnCommand, er
 
 func (odbi *ovndb) lspSetPortSecurityImp(lsp string, security ...string) (*OvnCommand, error) {
 	row := make(OVNRow)
-	port_security, err := libovsdb.NewOvsSet(security)
-	if err != nil {
-		return nil, err
-	}
-	row["port_security"] = port_security
+	row["port_security"] = strings.Join(security, " ")
 	condition := libovsdb.NewCondition("name", "==", lsp)
 	updateOp := libovsdb.Operation{
 		Op:    opUpdate,


### PR DESCRIPTION
OVN NB expects the addresses to be a single string and not a slice.
Using a slice causes:
invalid syntax '10.128.2.3' in logical switch port addresses. No MAC address found
invalid syntax '10.128.2.3' in port security. No MAC address found

The GoSet object is a slice of addresses instead of a single string:
GoSet:[0a:58:0a:80:04:04 10.128.4.4]

Which causes a newline when we do ovn-nbctl lsp-get-addresses:

0a:58:0a:80:04:03
10.128.4.3

Signed-off-by: Tim Rozet <trozet@redhat.com>