### PR TITLE
in ChassisGet API iterate to the next chassis after a match

### DIFF
--- a/chassis.go
+++ b/chassis.go
@@ -142,8 +142,7 @@ func (odbi *ovndb) chassisGetImp(chassis string) ([]*Chassis, error) {
 				return nil, err
 			}
 			listChassis = append(listChassis, ch)
-		}
-		if chName, ok := drows.Fields["name"].(string); ok && chName == chassis {
+		} else if chName, ok := drows.Fields["name"].(string); ok && chName == chassis {
 			ch, err := odbi.rowToChassis(uuid)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
currently, we try to match twice while matching once is enough

@vtolstov @hzhou8 @noah8713 PTAL. Thanks