### PR TITLE
Support for monitoring selected tables in OVN NB or SB DB

### DIFF
--- a/client.go
+++ b/client.go
@@ -223,12 +223,18 @@ type ovndb struct {
 	reconn       bool
 }
 
-func connect(c *ovndb) error {
+func connect(c *ovndb) (err error) {
 	ovsdb, err := libovsdb.Connect(c.addr, c.tlsConfig)
 	if err != nil {
 		return err
 	}
 	c.client = ovsdb
+	defer func() {
+		if err != nil {
+			c.client.Disconnect()
+			c.client = nil
+		}
+	}()
 	initial, err := ovsdb.MonitorAll(c.db, "")
 	if err != nil {
 		return err

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,141 @@
+package goovn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewClient_InvalidNBTables(t *testing.T) {
+	cfg := buildOvnDbConfig(DBNB)
+	cfg.TableCols = map[string][]string{
+		"Table1": {},
+	}
+	_, err := NewClient(cfg)
+	assert.Error(t, err)
+	t.Log(err.Error())
+}
+
+func TestNewClient_ValidNBTableInvalidCol(t *testing.T) {
+	cfg := buildOvnDbConfig(DBNB)
+	cfg.TableCols = map[string][]string{
+		"Logical_Switch_Port": {"col1"},
+	}
+	_, err := NewClient(cfg)
+	assert.Error(t, err)
+	t.Log(err.Error())
+}
+
+func TestNewClient_ValidNBTableCols(t *testing.T) {
+	cfg := buildOvnDbConfig(DBNB)
+	cfg.TableCols = map[string][]string{
+		"Logical_Switch": {},
+	}
+	api, err := NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create Switch with some values in external_ids
+	t.Logf("Adding %s to OVN with external_ids set", LS3)
+	cmd, err := api.LSAdd(LS3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = api.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Add external_ids to LS3
+	external_ids := map[string]string{NEUTRON_NETWORK: DUMMY, FOO: BAR}
+	cmd, err = api.LSExtIdsAdd(LS3, external_ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// execute the commands
+	err = api.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get the logical switch
+	ls, err := api.LSGet(LS3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, ls[0].Name, LS3)
+	assert.Equal(t, ls[0].ExternalID[NEUTRON_NETWORK], external_ids[NEUTRON_NETWORK])
+	assert.Equal(t, ls[0].ExternalID[FOO], external_ids[FOO])
+
+	// Finally delete Switch
+	t.Logf("Deleting LS3")
+	cmd, err = ovndbapi.LSDel(LS3)
+	if err != nil && err != ErrorNotFound {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatalf("err executing command:%v", err)
+	}
+	t.Logf("Deleting LS3 Done")
+
+	// Create a Logical Router and we should not be able to list the LR since
+	// we didn't express interest in the Logical_Router table
+	t.Logf("Adding LR %s", LR)
+	cmd, err = api.LRAdd(LR, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = api.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Listing LR %s", LR)
+	// We will not get the LR since we are not monitoring it.
+	_, err = api.LRList()
+	assert.Equal(t, err, ErrorNotFound)
+
+	// We cannot delete the LR since the client doesn't have the info for it.
+	_ = api.Close()
+	cfg = buildOvnDbConfig(DBNB)
+	cfg.TableCols = map[string][]string{
+		"Logical_Router": {},
+	}
+	api, err = NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// finally delete the logical router
+	t.Logf("Deleting LR %s", LR)
+	cmd, err = ovndbapi.LRDel(LR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Deleting LR %s Done", LR)
+}
+
+func TestNewClient_InvalidSBTables(t *testing.T) {
+	cfg := buildOvnDbConfig(DBSB)
+	cfg.TableCols = map[string][]string{
+		"Table1": {},
+	}
+	_, err := NewClient(cfg)
+	assert.Error(t, err)
+	t.Log(err.Error())
+}
+
+func TestNewClient_ValidSBTableInvalidCol(t *testing.T) {
+	cfg := buildOvnDbConfig(DBSB)
+	cfg.TableCols = map[string][]string{
+		"Chassis": {"col1"},
+	}
+	_, err := NewClient(cfg)
+	assert.Error(t, err)
+	t.Log(err.Error())
+}

--- a/common.go
+++ b/common.go
@@ -54,7 +54,7 @@ const (
 	tableSBGlobal                 string = "SB_Global"
 )
 
-var tablesOrder = []string{
+var NBTablesOrder = []string{
 	tableNBGlobal,
 	tableAddressSet,
 	tableACL,
@@ -74,6 +74,9 @@ var tablesOrder = []string{
 	tablePortGroup,
 	tableLogicalSwitch,
 	tableLogicalRouter,
+}
+
+var SBTablesOrder = []string{
 	tableChassis,
 	tableEncap,
 	tableSBGlobal,

--- a/config.go
+++ b/config.go
@@ -28,4 +28,5 @@ type Config struct {
 	SignalCB     OVNSignal
 	DisconnectCB OVNDisconnectedCallback // Callback that is called when disconnected, if "Reconnect" is false.
 	Reconnect    bool                    // Automatically reconnect when disconnected
+	TableCols    map[string][]string     // List of tables and their cols to be monitored
 }

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -210,7 +210,7 @@ func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 	odbi.cachemutex.Lock()
 	defer odbi.cachemutex.Unlock()
 
-	for _, table := range tablesOrder {
+	for table := range odbi.tableCols {
 		tableUpdate, ok := updates.Updates[table]
 		if !ok {
 			continue

--- a/test_common.go
+++ b/test_common.go
@@ -53,9 +53,7 @@ var (
 	ovn_socket string
 )
 
-func getOVNClient(db string) (ovndbapi Client) {
-	var api Client
-	var err error
+func buildOvnDbConfig(db string) *Config {
 	cfg := &Config{}
 	if db == DBNB || db == "" {
 		ovn_db = os.Getenv("OVN_NB_DB")
@@ -73,11 +71,6 @@ func getOVNClient(db string) (ovndbapi Client) {
 
 	if ovn_db == "" {
 		cfg.Addr = UNIX + ":" + ovs_rundir + "/" + ovn_socket
-
-		api, err = NewClient(cfg)
-		if err != nil {
-			log.Fatal(err)
-		}
 	} else {
 		strs := strings.Split(ovn_db, ":")
 		fmt.Println(strs)
@@ -86,10 +79,6 @@ func getOVNClient(db string) (ovndbapi Client) {
 		}
 		if len(strs) == 2 {
 			cfg.Addr = UNIX + ":" + ovs_rundir + "/" + strs[1]
-			api, err = NewClient(cfg)
-			if err != nil {
-				log.Fatal(err)
-			}
 		} else {
 			port, _ := strconv.Atoi(strs[2])
 			protocol := strs[0]
@@ -122,13 +111,17 @@ func getOVNClient(db string) (ovndbapi Client) {
 				}
 				cfg.TLSConfig = &tlsConfig
 			}
-
 			cfg.Addr = fmt.Sprintf("%s:%s:%d", strs[0], strs[1], port)
-			api, err = NewClient(cfg)
-			if err != nil {
-				log.Fatal(err)
-			}
 		}
+	}
+	return cfg
+}
+
+func getOVNClient(db string) (ovndbapi Client) {
+	cfg := buildOvnDbConfig(db)
+	api, err := NewClient(cfg)
+	if err != nil {
+		log.Fatal(err)
 	}
 	return api
 }


### PR DESCRIPTION
this commit adds a new field to Config struct called TableCols which
is of type map[string][]string (maps table names to columns). with this
user can specify what tables in NB or in SB they would like to Monitor.

in a large scale OVN K8s cluster, the SB DB will be huge with 1000s of
entries in various tables (Logical_Flow, Port_Binding, adn so on),
neither do we want to get the initial data for these tables nor we want
updates for these tables and this commit provides a way to specify the
tables the user is interested in

adding support for specific columns within a table needs some more work
since all of the rowTo<tableName>() functions need to be updated to
reflect missing fields in the Row (since client expressed interest in
only subset of rows)

@noah8713 @hzhou8 @vtolstov PTAL