### PR TITLE
Make table constants as exportable

### DIFF
--- a/acl.go
+++ b/acl.go
@@ -37,7 +37,7 @@ func (odbi *ovndb) getACLUUIDByRow(lsw, table string, row OVNRow) (string, error
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalSwitch, ok := odbi.cache[tableLogicalSwitch]
+	cacheLogicalSwitch, ok := odbi.cache[TableLogicalSwitch]
 	if !ok {
 		return "", ErrorSchema
 	}
@@ -51,7 +51,7 @@ func (odbi *ovndb) getACLUUIDByRow(lsw, table string, row OVNRow) (string, error
 					if as, ok := acls.(libovsdb.OvsSet); ok {
 						for _, a := range as.GoSet {
 							if va, ok := a.(libovsdb.UUID); ok {
-								cacheACL, ok := odbi.cache[tableACL][va.GoUUID]
+								cacheACL, ok := odbi.cache[TableACL][va.GoUUID]
 								if !ok {
 									return "", ErrorSchema
 								}
@@ -91,7 +91,7 @@ func (odbi *ovndb) getACLUUIDByRow(lsw, table string, row OVNRow) (string, error
 					}
 				case libovsdb.UUID:
 					if va, ok := acls.(libovsdb.UUID); ok {
-						cacheACL, ok := odbi.cache[tableACL][va.GoUUID]
+						cacheACL, ok := odbi.cache[TableACL][va.GoUUID]
 						if !ok {
 							return "", ErrorSchema
 						}
@@ -152,7 +152,7 @@ func (odbi *ovndb) aclAddImp(lsw, direct, match, action string, priority int, ex
 		row["external_ids"] = oMap
 	}
 
-	_, err = odbi.getACLUUIDByRow(lsw, tableACL, row)
+	_, err = odbi.getACLUUIDByRow(lsw, TableACL, row)
 	switch err {
 	case ErrorNotFound:
 		break
@@ -180,7 +180,7 @@ func (odbi *ovndb) aclAddImp(lsw, direct, match, action string, priority int, ex
 	}
 	insertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableACL,
+		Table:    TableACL,
 		Row:      row,
 		UUIDName: namedUUID,
 	}
@@ -196,7 +196,7 @@ func (odbi *ovndb) aclAddImp(lsw, direct, match, action string, priority int, ex
 	// simple mutate operation
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitch,
+		Table:     TableLogicalSwitch,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -228,7 +228,7 @@ func (odbi *ovndb) aclDelImp(lsw, direct, match string, priority int, external_i
 		row["external_ids"] = oMap
 	}
 
-	aclUUID, err := odbi.getACLUUIDByRow(lsw, tableACL, row)
+	aclUUID, err := odbi.getACLUUIDByRow(lsw, TableACL, row)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (odbi *ovndb) aclDelImp(lsw, direct, match string, priority int, external_i
 	wherecondition = append(wherecondition, uuidcondition)
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tableACL,
+		Table: TableACL,
 		Where: wherecondition,
 	}
 
@@ -247,7 +247,7 @@ func (odbi *ovndb) aclDelImp(lsw, direct, match string, priority int, external_i
 	// Simple mutate operation
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitch,
+		Table:     TableLogicalSwitch,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -256,7 +256,7 @@ func (odbi *ovndb) aclDelImp(lsw, direct, match string, priority int, external_i
 }
 
 func (odbi *ovndb) rowToACL(uuid string) *ACL {
-	cacheACL, ok := odbi.cache[tableACL][uuid]
+	cacheACL, ok := odbi.cache[TableACL][uuid]
 	if !ok {
 		return nil
 	}
@@ -305,7 +305,7 @@ func (odbi *ovndb) aclListImp(lsw string) ([]*ACL, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalSwitch, ok := odbi.cache[tableLogicalSwitch]
+	cacheLogicalSwitch, ok := odbi.cache[TableLogicalSwitch]
 	if !ok {
 		return nil, ErrorNotFound
 	}

--- a/address_set.go
+++ b/address_set.go
@@ -47,7 +47,7 @@ func (odbi *ovndb) asUpdateImp(name string, addrs []string, external_ids map[str
 	condition := libovsdb.NewCondition("name", "==", name)
 	updateOp := libovsdb.Operation{
 		Op:    opUpdate,
-		Table: tableAddressSet,
+		Table: TableAddressSet,
 		Row:   row,
 		Where: []interface{}{condition},
 	}
@@ -60,7 +60,7 @@ func (odbi *ovndb) asAddImp(name string, addrs []string, external_ids map[string
 	row["name"] = name
 	//should support the -is-exist flag here.
 
-	if uuid := odbi.getRowUUID(tableAddressSet, row); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TableAddressSet, row); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
 
@@ -78,7 +78,7 @@ func (odbi *ovndb) asAddImp(name string, addrs []string, external_ids map[string
 	row["addresses"] = addresses
 	insertOp := libovsdb.Operation{
 		Op:    opInsert,
-		Table: tableAddressSet,
+		Table: TableAddressSet,
 		Row:   row,
 	}
 	operations := []libovsdb.Operation{insertOp}
@@ -104,7 +104,7 @@ func (odbi *ovndb) asDelImp(name string) (*OvnCommand, error) {
 	condition := libovsdb.NewCondition("name", "==", name)
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tableAddressSet,
+		Table: TableAddressSet,
 		Where: []interface{}{condition},
 	}
 	operations := []libovsdb.Operation{deleteOp}
@@ -118,7 +118,7 @@ func (odbi *ovndb) asListImp() ([]*AddressSet, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheAddressSet, ok := odbi.cache[tableAddressSet]
+	cacheAddressSet, ok := odbi.cache[TableAddressSet]
 	if !ok {
 		return nil, ErrorSchema
 	}

--- a/chassis.go
+++ b/chassis.go
@@ -61,12 +61,12 @@ func (odbi *ovndb) chassisAddImp(name string, hostname string, etype []string, i
 		encap_ids = append(encap_ids, encap_id)
 		row["ip"] = ip
 		row["type"] = et
-		if uuid := odbi.getRowUUID(tableEncap, row); len(uuid) > 0 {
+		if uuid := odbi.getRowUUID(TableEncap, row); len(uuid) > 0 {
 			return nil, ErrorExist
 		}
 		insertEncapOp := libovsdb.Operation{
 			Op:       opInsert,
-			Table:    tableEncap,
+			Table:    TableEncap,
 			Row:      row,
 			UUIDName: enCapUUID,
 		}
@@ -101,7 +101,7 @@ func (odbi *ovndb) chassisAddImp(name string, hostname string, etype []string, i
 	}
 	insertChassisOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableChassis,
+		Table:    TableChassis,
 		Row:      rowChassis,
 		UUIDName: ChassisUUID,
 	}
@@ -116,7 +116,7 @@ func (odbi *ovndb) chassisDelImp(name string) (*OvnCommand, error) {
 	condition := libovsdb.NewCondition("name", "==", name)
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tableChassis,
+		Table: TableChassis,
 		Where: []interface{}{condition},
 	}
 	operations = append(operations, deleteOp)
@@ -129,7 +129,7 @@ func (odbi *ovndb) chassisListImp() ([]*Chassis, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheChassis, ok := odbi.cache[tableChassis]
+	cacheChassis, ok := odbi.cache[TableChassis]
 
 	if !ok {
 		return nil, ErrorSchema
@@ -151,7 +151,7 @@ func (odbi *ovndb) chassisGetImp(chassis string) ([]*Chassis, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheChassis, ok := odbi.cache[tableChassis]
+	cacheChassis, ok := odbi.cache[TableChassis]
 
 	if !ok {
 		return nil, ErrorSchema
@@ -177,7 +177,7 @@ func (odbi *ovndb) chassisGetImp(chassis string) ([]*Chassis, error) {
 
 func (odbi *ovndb) rowToChassis(uuid string) (*Chassis, error) {
 
-	cacheChassis, ok := odbi.cache[tableChassis][uuid]
+	cacheChassis, ok := odbi.cache[TableChassis][uuid]
 	if !ok {
 		return nil, fmt.Errorf("Chassis with uuid%s not found", uuid)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -6,10 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const DUMMYTABLE = "Table1"
+
 func TestNewClient_InvalidNBTables(t *testing.T) {
 	cfg := buildOvnDbConfig(DBNB)
 	cfg.TableCols = map[string][]string{
-		"Table1": {},
+		DUMMYTABLE: {},
 	}
 	_, err := NewClient(cfg)
 	assert.Error(t, err)
@@ -19,7 +21,7 @@ func TestNewClient_InvalidNBTables(t *testing.T) {
 func TestNewClient_ValidNBTableInvalidCol(t *testing.T) {
 	cfg := buildOvnDbConfig(DBNB)
 	cfg.TableCols = map[string][]string{
-		"Logical_Switch_Port": {"col1"},
+		TableLogicalSwitchPort: {"col1"},
 	}
 	_, err := NewClient(cfg)
 	assert.Error(t, err)
@@ -29,7 +31,7 @@ func TestNewClient_ValidNBTableInvalidCol(t *testing.T) {
 func TestNewClient_ValidNBTableCols(t *testing.T) {
 	cfg := buildOvnDbConfig(DBNB)
 	cfg.TableCols = map[string][]string{
-		"Logical_Switch": {},
+		TableLogicalSwitch: {},
 	}
 	api, err := NewClient(cfg)
 	if err != nil {
@@ -100,7 +102,7 @@ func TestNewClient_ValidNBTableCols(t *testing.T) {
 	_ = api.Close()
 	cfg = buildOvnDbConfig(DBNB)
 	cfg.TableCols = map[string][]string{
-		"Logical_Router": {},
+		TableLogicalRouter: {},
 	}
 	api, err = NewClient(cfg)
 	if err != nil {
@@ -123,7 +125,7 @@ func TestNewClient_ValidNBTableCols(t *testing.T) {
 func TestNewClient_InvalidSBTables(t *testing.T) {
 	cfg := buildOvnDbConfig(DBSB)
 	cfg.TableCols = map[string][]string{
-		"Table1": {},
+		DUMMYTABLE: {},
 	}
 	_, err := NewClient(cfg)
 	assert.Error(t, err)
@@ -133,7 +135,7 @@ func TestNewClient_InvalidSBTables(t *testing.T) {
 func TestNewClient_ValidSBTableInvalidCol(t *testing.T) {
 	cfg := buildOvnDbConfig(DBSB)
 	cfg.TableCols = map[string][]string{
-		"Chassis": {"col1"},
+		TableChassis: {"col1"},
 	}
 	_, err := NewClient(cfg)
 	assert.Error(t, err)

--- a/common.go
+++ b/common.go
@@ -30,54 +30,54 @@ const (
 )
 
 const (
-	tableNBGlobal                 string = "NB_Global"
-	tableLogicalSwitch            string = "Logical_Switch"
-	tableLogicalSwitchPort        string = "Logical_Switch_Port"
-	tableAddressSet               string = "Address_Set"
-	tablePortGroup                string = "Port_Group"
-	tableLoadBalancer             string = "Load_Balancer"
-	tableACL                      string = "ACL"
-	tableLogicalRouter            string = "Logical_Router"
-	tableQoS                      string = "QoS"
-	tableMeter                    string = "Meter"
-	tableMeterBand                string = "Meter_Band"
-	tableLogicalRouterPort        string = "Logical_Router_Port"
-	tableLogicalRouterStaticRoute string = "Logical_Router_Static_Route"
-	tableNAT                      string = "NAT"
-	tableDHCPOptions              string = "DHCP_Options"
-	tableConnection               string = "Connection"
-	tableDNS                      string = "DNS"
-	tableSSL                      string = "SSL"
-	tableGatewayChassis           string = "Gateway_Chassis"
-	tableChassis                  string = "Chassis"
-	tableEncap                    string = "Encap"
-	tableSBGlobal                 string = "SB_Global"
+	TableNBGlobal                 string = "NB_Global"
+	TableLogicalSwitch            string = "Logical_Switch"
+	TableLogicalSwitchPort        string = "Logical_Switch_Port"
+	TableAddressSet               string = "Address_Set"
+	TablePortGroup                string = "Port_Group"
+	TableLoadBalancer             string = "Load_Balancer"
+	TableACL                      string = "ACL"
+	TableLogicalRouter            string = "Logical_Router"
+	TableQoS                      string = "QoS"
+	TableMeter                    string = "Meter"
+	TableMeterBand                string = "Meter_Band"
+	TableLogicalRouterPort        string = "Logical_Router_Port"
+	TableLogicalRouterStaticRoute string = "Logical_Router_Static_Route"
+	TableNAT                      string = "NAT"
+	TableDHCPOptions              string = "DHCP_Options"
+	TableConnection               string = "Connection"
+	TableDNS                      string = "DNS"
+	TableSSL                      string = "SSL"
+	TableGatewayChassis           string = "Gateway_Chassis"
+	TableChassis                  string = "Chassis"
+	TableEncap                    string = "Encap"
+	TableSBGlobal                 string = "SB_Global"
 )
 
 var NBTablesOrder = []string{
-	tableNBGlobal,
-	tableAddressSet,
-	tableACL,
-	tableDHCPOptions,
-	tableLoadBalancer,
-	tableQoS,
-	tableMeter,
-	tableMeterBand,
-	tableLogicalRouterPort,
-	tableLogicalRouterStaticRoute,
-	tableLogicalSwitchPort,
-	tableNAT,
-	tableConnection,
-	tableDNS,
-	tableSSL,
-	tableGatewayChassis,
-	tablePortGroup,
-	tableLogicalSwitch,
-	tableLogicalRouter,
+	TableNBGlobal,
+	TableAddressSet,
+	TableACL,
+	TableDHCPOptions,
+	TableLoadBalancer,
+	TableQoS,
+	TableMeter,
+	TableMeterBand,
+	TableLogicalRouterPort,
+	TableLogicalRouterStaticRoute,
+	TableLogicalSwitchPort,
+	TableNAT,
+	TableConnection,
+	TableDNS,
+	TableSSL,
+	TableGatewayChassis,
+	TablePortGroup,
+	TableLogicalSwitch,
+	TableLogicalRouter,
 }
 
 var SBTablesOrder = []string{
-	tableChassis,
-	tableEncap,
-	tableSBGlobal,
+	TableChassis,
+	TableEncap,
+	TableSBGlobal,
 }

--- a/dhcp_options.go
+++ b/dhcp_options.go
@@ -29,7 +29,7 @@ type DHCPOptions struct {
 }
 
 func (odbi *ovndb) rowToDHCPOptions(uuid string) *DHCPOptions {
-	cacheDHCPOptions, ok := odbi.cache[tableDHCPOptions][uuid]
+	cacheDHCPOptions, ok := odbi.cache[TableDHCPOptions][uuid]
 	if !ok {
 		return nil
 	}
@@ -83,7 +83,7 @@ func (odbi *ovndb) dhcpOptionsAddImp(cidr string, options map[string]string, ext
 
 	insertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableDHCPOptions,
+		Table:    TableDHCPOptions,
 		Row:      row,
 		UUIDName: namedUUID,
 	}
@@ -95,7 +95,7 @@ func (odbi *ovndb) dhcpOptionsAddImp(cidr string, options map[string]string, ext
 func (odbi *ovndb) dhcpOptionsSetImp(uuid string, options map[string]string, external_ids map[string]string) (*OvnCommand, error) {
 	row := make(OVNRow)
 
-	_, ok := odbi.cache[tableDHCPOptions][uuid]
+	_, ok := odbi.cache[TableDHCPOptions][uuid]
 	if !ok {
 		return nil, ErrorNotFound
 	}
@@ -122,7 +122,7 @@ func (odbi *ovndb) dhcpOptionsSetImp(uuid string, options map[string]string, ext
 
 	mutateOp := libovsdb.Operation{
 		Op:    opUpdate,
-		Table: tableDHCPOptions,
+		Table: TableDHCPOptions,
 		Row:   row,
 		Where: []interface{}{condition},
 	}
@@ -135,7 +135,7 @@ func (odbi *ovndb) dhcpOptionsDelImp(uuid string) (*OvnCommand, error) {
 	condition := libovsdb.NewCondition("_uuid", "==", stringToGoUUID(uuid))
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tableDHCPOptions,
+		Table: TableDHCPOptions,
 		Where: []interface{}{condition},
 	}
 	operations := []libovsdb.Operation{deleteOp}
@@ -149,7 +149,7 @@ func (odbi *ovndb) dhcpOptionsListImp() ([]*DHCPOptions, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheDHCPOptions, ok := odbi.cache[tableDHCPOptions]
+	cacheDHCPOptions, ok := odbi.cache[TableDHCPOptions]
 	if !ok {
 		return nil, ErrorSchema
 	}

--- a/encap.go
+++ b/encap.go
@@ -35,7 +35,7 @@ func (odbi *ovndb) encapListImp(chassisName string) ([]*Encap, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheChassis, ok := odbi.cache[tableChassis]
+	cacheChassis, ok := odbi.cache[TableChassis]
 	if !ok {
 		return nil, ErrorNotFound
 	}
@@ -84,7 +84,7 @@ func (odbi *ovndb) encapListImp(chassisName string) ([]*Encap, error) {
 }
 
 func (odbi *ovndb) rowToEncap(uuid string) (*Encap, error) {
-	cacheEncaps, ok := odbi.cache[tableEncap][uuid]
+	cacheEncaps, ok := odbi.cache[TableEncap][uuid]
 	if !ok {
 		return nil, fmt.Errorf("Encap with uuid%s not found", uuid)
 	}

--- a/load_balancer.go
+++ b/load_balancer.go
@@ -50,7 +50,7 @@ func (odbi *ovndb) lbUpdateImp(name string, vipPort string, protocol string, add
 
 	insertOp := libovsdb.Operation{
 		Op:    opUpdate,
-		Table: tableLoadBalancer,
+		Table: TableLoadBalancer,
 		Row:   row,
 		Where: []interface{}{condition},
 	}
@@ -68,7 +68,7 @@ func (odbi *ovndb) lbAddImp(name string, vipPort string, protocol string, addrs 
 	row := make(OVNRow)
 	row["name"] = name
 
-	if uuid := odbi.getRowUUID(tableLoadBalancer, row); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TableLoadBalancer, row); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
 
@@ -85,7 +85,7 @@ func (odbi *ovndb) lbAddImp(name string, vipPort string, protocol string, addrs 
 
 	insertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableLoadBalancer,
+		Table:    TableLoadBalancer,
 		Row:      row,
 		UUIDName: namedUUID,
 	}
@@ -99,13 +99,13 @@ func (odbi *ovndb) lbDelImp(name string) (*OvnCommand, error) {
 	condition := libovsdb.NewCondition("name", "==", name)
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tableLoadBalancer,
+		Table: TableLoadBalancer,
 		Where: []interface{}{condition},
 	}
 	// Also delete references from Logical switches
 	row := make(OVNRow)
 	row["name"] = name
-	lbuuid := odbi.getRowUUID(tableLoadBalancer, row)
+	lbuuid := odbi.getRowUUID(TableLoadBalancer, row)
 	if len(lbuuid) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -115,7 +115,7 @@ func (odbi *ovndb) lbDelImp(name string) (*OvnCommand, error) {
 		return nil, err
 	}
 	mutation := libovsdb.NewMutation("load_balancer", opDelete, mutateSet)
-	lswitches, err := odbi.getRowsMatchingUUID(tableLogicalSwitch, "load_balancer", lbuuid)
+	lswitches, err := odbi.getRowsMatchingUUID(TableLogicalSwitch, "load_balancer", lbuuid)
 	if err != nil && err != ErrorNotFound {
 		return nil, err
 	} else if err == nil {
@@ -124,7 +124,7 @@ func (odbi *ovndb) lbDelImp(name string) (*OvnCommand, error) {
 			mucondition := libovsdb.NewCondition("_uuid", "==", stringToGoUUID(lswitch))
 			mutateOp := libovsdb.Operation{
 				Op:        opMutate,
-				Table:     tableLogicalSwitch,
+				Table:     TableLogicalSwitch,
 				Mutations: []interface{}{mutation},
 				Where:     []interface{}{mucondition},
 			}
@@ -141,7 +141,7 @@ func (odbi *ovndb) lbGetImp(name string) ([]*LoadBalancer, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLoadBalancer, ok := odbi.cache[tableLoadBalancer]
+	cacheLoadBalancer, ok := odbi.cache[TableLoadBalancer]
 	if !ok {
 		return nil, ErrorSchema
 	}
@@ -159,7 +159,7 @@ func (odbi *ovndb) lbGetImp(name string) ([]*LoadBalancer, error) {
 }
 
 func (odbi *ovndb) rowToLB(uuid string) (*LoadBalancer, error) {
-	cacheLoadBalancer, ok := odbi.cache[tableLoadBalancer][uuid]
+	cacheLoadBalancer, ok := odbi.cache[TableLoadBalancer][uuid]
 	if !ok {
 		return nil, ErrorSchema
 	}

--- a/logical_router.go
+++ b/logical_router.go
@@ -54,13 +54,13 @@ func (odbi *ovndb) lrAddImp(name string, external_ids map[string]string) (*OvnCo
 		row["external_ids"] = oMap
 	}
 
-	if uuid := odbi.getRowUUID(tableLogicalRouter, row); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TableLogicalRouter, row); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
 
 	insertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableLogicalRouter,
+		Table:    TableLogicalRouter,
 		Row:      row,
 		UUIDName: namedUUID,
 	}
@@ -73,7 +73,7 @@ func (odbi *ovndb) lrDelImp(name string) (*OvnCommand, error) {
 	condition := libovsdb.NewCondition("name", "==", name)
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tableLogicalRouter,
+		Table: TableLogicalRouter,
 		Where: []interface{}{condition},
 	}
 	operations := []libovsdb.Operation{deleteOp}
@@ -86,7 +86,7 @@ func (odbi *ovndb) lrGetImp(name string) ([]*LogicalRouter, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalRouter, ok := odbi.cache[tableLogicalRouter]
+	cacheLogicalRouter, ok := odbi.cache[TableLogicalRouter]
 	if !ok {
 		return nil, ErrorNotFound
 	}
@@ -103,12 +103,12 @@ func (odbi *ovndb) lrGetImp(name string) ([]*LogicalRouter, error) {
 func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
 	lr := &LogicalRouter{
 		UUID:       uuid,
-		Name:       odbi.cache[tableLogicalRouter][uuid].Fields["name"].(string),
-		Options:    odbi.cache[tableLogicalRouter][uuid].Fields["options"].(libovsdb.OvsMap).GoMap,
-		ExternalID: odbi.cache[tableLogicalRouter][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		Name:       odbi.cache[TableLogicalRouter][uuid].Fields["name"].(string),
+		Options:    odbi.cache[TableLogicalRouter][uuid].Fields["options"].(libovsdb.OvsMap).GoMap,
+		ExternalID: odbi.cache[TableLogicalRouter][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
 	}
 
-	if enabled, ok := odbi.cache[tableLogicalRouter][uuid].Fields["enabled"]; ok {
+	if enabled, ok := odbi.cache[TableLogicalRouter][uuid].Fields["enabled"]; ok {
 		switch enabled.(type) {
 		case bool:
 			lr.Enabled = enabled.(bool)
@@ -120,7 +120,7 @@ func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
 	}
 
 	var lbs []string
-	load_balancer := odbi.cache[tableLogicalRouter][uuid].Fields["load_balancer"]
+	load_balancer := odbi.cache[TableLogicalRouter][uuid].Fields["load_balancer"]
 	if load_balancer != nil {
 		switch load_balancer.(type) {
 		case libovsdb.OvsSet:
@@ -143,7 +143,7 @@ func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
 	lr.LoadBalancer = lbs
 
 	var lps []string
-	ports := odbi.cache[tableLogicalRouter][uuid].Fields["ports"]
+	ports := odbi.cache[TableLogicalRouter][uuid].Fields["ports"]
 	if ports != nil {
 		switch ports.(type) {
 		case string:
@@ -167,7 +167,7 @@ func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
 	lr.Ports = lps
 
 	var listLRSR []string
-	staticRoutes := odbi.cache[tableLogicalRouter][uuid].Fields["static_routes"]
+	staticRoutes := odbi.cache[TableLogicalRouter][uuid].Fields["static_routes"]
 	if staticRoutes != nil {
 		switch staticRoutes.(type) {
 		case libovsdb.OvsSet:
@@ -189,7 +189,7 @@ func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
 	lr.StaticRoutes = listLRSR
 
 	var NATList []string
-	nat := odbi.cache[tableLogicalRouter][uuid].Fields["nat"]
+	nat := odbi.cache[TableLogicalRouter][uuid].Fields["nat"]
 	if nat != nil {
 		switch nat.(type) {
 		case libovsdb.OvsSet:
@@ -220,7 +220,7 @@ func (odbi *ovndb) lrListImp() ([]*LogicalRouter, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalRouter, ok := odbi.cache[tableLogicalRouter]
+	cacheLogicalRouter, ok := odbi.cache[TableLogicalRouter]
 	if !ok {
 		return nil, ErrorNotFound
 	}
@@ -236,7 +236,7 @@ func (odbi *ovndb) lrlbAddImp(lr string, lb string) (*OvnCommand, error) {
 	var operations []libovsdb.Operation
 	row := make(OVNRow)
 	row["name"] = lb
-	lbuuid := odbi.getRowUUID(tableLoadBalancer, row)
+	lbuuid := odbi.getRowUUID(TableLoadBalancer, row)
 	if len(lbuuid) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -248,14 +248,14 @@ func (odbi *ovndb) lrlbAddImp(lr string, lb string) (*OvnCommand, error) {
 	}
 	row = make(OVNRow)
 	row["name"] = lr
-	lruuid := odbi.getRowUUID(tableLogicalRouter, row)
+	lruuid := odbi.getRowUUID(TableLogicalRouter, row)
 	if len(lruuid) == 0 {
 		return nil, ErrorNotFound
 	}
 	condition := libovsdb.NewCondition("name", "==", lr)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalRouter,
+		Table:     TableLogicalRouter,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -267,7 +267,7 @@ func (odbi *ovndb) lrlbDelImp(lr string, lb string) (*OvnCommand, error) {
 	var operations []libovsdb.Operation
 	row := make(OVNRow)
 	row["name"] = lb
-	lbuuid := odbi.getRowUUID(tableLoadBalancer, row)
+	lbuuid := odbi.getRowUUID(TableLoadBalancer, row)
 	if len(lbuuid) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -278,7 +278,7 @@ func (odbi *ovndb) lrlbDelImp(lr string, lb string) (*OvnCommand, error) {
 	}
 	row = make(OVNRow)
 	row["name"] = lr
-	lruuid := odbi.getRowUUID(tableLogicalRouter, row)
+	lruuid := odbi.getRowUUID(TableLogicalRouter, row)
 	if len(lruuid) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -287,7 +287,7 @@ func (odbi *ovndb) lrlbDelImp(lr string, lb string) (*OvnCommand, error) {
 	mucondition := libovsdb.NewCondition("name", "==", lr)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalRouter,
+		Table:     TableLogicalRouter,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{mucondition},
 	}
@@ -300,7 +300,7 @@ func (odbi *ovndb) lrlbListImp(lr string) ([]*LoadBalancer, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalRouter, ok := odbi.cache[tableLogicalRouter]
+	cacheLogicalRouter, ok := odbi.cache[TableLogicalRouter]
 	if !ok {
 		return nil, ErrorSchema
 	}

--- a/logical_router_port.go
+++ b/logical_router_port.go
@@ -62,13 +62,13 @@ func (odbi *ovndb) lrpAddImp(lr string, lrp string, mac string, network []string
 		row["external_ids"] = oMap
 	}
 
-	if uuid := odbi.getRowUUID(tableLogicalRouterPort, row); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TableLogicalRouterPort, row); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
 
 	insertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableLogicalRouterPort,
+		Table:    TableLogicalRouterPort,
 		Row:      row,
 		UUIDName: namedUUID,
 	}
@@ -83,7 +83,7 @@ func (odbi *ovndb) lrpAddImp(lr string, lrp string, mac string, network []string
 
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalRouter,
+		Table:     TableLogicalRouter,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -96,7 +96,7 @@ func (odbi *ovndb) lrpDelImp(lr, lrp string) (*OvnCommand, error) {
 	row := make(OVNRow)
 	row["name"] = lrp
 
-	lrpUUID := odbi.getRowUUID(tableLogicalRouterPort, row)
+	lrpUUID := odbi.getRowUUID(TableLogicalRouterPort, row)
 	if len(lrpUUID) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -105,7 +105,7 @@ func (odbi *ovndb) lrpDelImp(lr, lrp string) (*OvnCommand, error) {
 	condition := libovsdb.NewCondition("name", "==", lr)
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tableLogicalRouterPort,
+		Table: TableLogicalRouterPort,
 		Where: []interface{}{condition},
 	}
 	mutateSet, err := libovsdb.NewOvsSet(mutateUUID)
@@ -113,7 +113,7 @@ func (odbi *ovndb) lrpDelImp(lr, lrp string) (*OvnCommand, error) {
 		return nil, err
 	}
 	mutation := libovsdb.NewMutation("ports", opDelete, mutateSet)
-	ucondition, err := odbi.getRowUUIDContainsUUID(tableLogicalRouter, "ports", lrpUUID)
+	ucondition, err := odbi.getRowUUIDContainsUUID(TableLogicalRouter, "ports", lrpUUID)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (odbi *ovndb) lrpDelImp(lr, lrp string) (*OvnCommand, error) {
 	// simple mutate operation
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalRouter,
+		Table:     TableLogicalRouter,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{mucondition},
 	}
@@ -133,27 +133,27 @@ func (odbi *ovndb) lrpDelImp(lr, lrp string) (*OvnCommand, error) {
 func (odbi *ovndb) rowToLogicalRouterPort(uuid string) *LogicalRouterPort {
 	lrp := &LogicalRouterPort{
 		UUID:       uuid,
-		Name:       odbi.cache[tableLogicalRouterPort][uuid].Fields["name"].(string),
-		MAC:        odbi.cache[tableLogicalRouterPort][uuid].Fields["mac"].(string),
-		ExternalID: odbi.cache[tableLogicalRouterPort][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		Name:       odbi.cache[TableLogicalRouterPort][uuid].Fields["name"].(string),
+		MAC:        odbi.cache[TableLogicalRouterPort][uuid].Fields["mac"].(string),
+		ExternalID: odbi.cache[TableLogicalRouterPort][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
 	}
 
-	if peer, ok := odbi.cache[tableLogicalRouterPort][uuid].Fields["peer"]; ok {
+	if peer, ok := odbi.cache[TableLogicalRouterPort][uuid].Fields["peer"]; ok {
 		switch peer.(type) {
 		case string:
 			lrp.Peer = peer.(string)
 		}
 	}
 
-	if options, ok := odbi.cache[tableLogicalRouterPort][uuid].Fields["options"]; ok {
+	if options, ok := odbi.cache[TableLogicalRouterPort][uuid].Fields["options"]; ok {
 		lrp.Options = options.(libovsdb.OvsMap).GoMap
 	}
 
-	if ipv6_ra_configs, ok := odbi.cache[tableLogicalRouterPort][uuid].Fields["ipv6_ra_configs"]; ok {
+	if ipv6_ra_configs, ok := odbi.cache[TableLogicalRouterPort][uuid].Fields["ipv6_ra_configs"]; ok {
 		lrp.IPv6RAConfigs = ipv6_ra_configs.(libovsdb.OvsMap).GoMap
 	}
 
-	if enabled, ok := odbi.cache[tableLogicalRouterPort][uuid].Fields["enabled"]; ok {
+	if enabled, ok := odbi.cache[TableLogicalRouterPort][uuid].Fields["enabled"]; ok {
 		switch enabled.(type) {
 		case bool:
 			lrp.Enabled = enabled.(bool)
@@ -164,14 +164,14 @@ func (odbi *ovndb) rowToLogicalRouterPort(uuid string) *LogicalRouterPort {
 		}
 	}
 
-	gateway_chassis := odbi.cache[tableLogicalRouterPort][uuid].Fields["gateway_chassis"]
+	gateway_chassis := odbi.cache[TableLogicalRouterPort][uuid].Fields["gateway_chassis"]
 	switch gateway_chassis.(type) {
 	case string:
 		lrp.GatewayChassis = []string{gateway_chassis.(string)}
 	case libovsdb.OvsSet:
 		lrp.GatewayChassis = odbi.ConvertGoSetToStringArray(gateway_chassis.(libovsdb.OvsSet))
 	}
-	networks := odbi.cache[tableLogicalRouterPort][uuid].Fields["networks"]
+	networks := odbi.cache[TableLogicalRouterPort][uuid].Fields["networks"]
 	switch networks.(type) {
 	case string:
 		lrp.Networks = []string{networks.(string)}
@@ -188,7 +188,7 @@ func (odbi *ovndb) lrpListImp(lr string) ([]*LogicalRouterPort, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalRouter, ok := odbi.cache[tableLogicalRouter]
+	cacheLogicalRouter, ok := odbi.cache[TableLogicalRouter]
 	if !ok {
 		return nil, ErrorNotFound
 	}

--- a/logical_router_static_route.go
+++ b/logical_router_static_route.go
@@ -55,13 +55,13 @@ func (odbi *ovndb) lrsrAddImp(lr string, ip_prefix string, nexthop string, outpu
 		row["external_ids"] = oMap
 	}
 
-	if uuid := odbi.getRowUUID(tableLogicalRouterStaticRoute, row); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TableLogicalRouterStaticRoute, row); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
 
 	insertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableLogicalRouterStaticRoute,
+		Table:    TableLogicalRouterStaticRoute,
 		Row:      row,
 		UUIDName: namedUUID,
 	}
@@ -76,7 +76,7 @@ func (odbi *ovndb) lrsrAddImp(lr string, ip_prefix string, nexthop string, outpu
 
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalRouter,
+		Table:     TableLogicalRouter,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -104,7 +104,7 @@ func (odbi *ovndb) lrsrDelImp(lr string, prefix string, nexthop, policy, outputP
 	if outputPort != nil {
 		row["output_port"] = []string{*outputPort}
 	}
-	lrsruuid := odbi.getRowUUID(tableLogicalRouterStaticRoute, row)
+	lrsruuid := odbi.getRowUUID(TableLogicalRouterStaticRoute, row)
 	if len(lrsruuid) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -115,7 +115,7 @@ func (odbi *ovndb) lrsrDelImp(lr string, prefix string, nexthop, policy, outputP
 	}
 	row = make(OVNRow)
 	row["name"] = lr
-	lruuid := odbi.getRowUUID(tableLogicalRouter, row)
+	lruuid := odbi.getRowUUID(TableLogicalRouter, row)
 	if len(lruuid) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -124,7 +124,7 @@ func (odbi *ovndb) lrsrDelImp(lr string, prefix string, nexthop, policy, outputP
 	mucondition := libovsdb.NewCondition("name", "==", lr)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalRouter,
+		Table:     TableLogicalRouter,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{mucondition},
 	}
@@ -141,7 +141,7 @@ func (odbi *ovndb) lrsrDelByUUIDImp(lr, uuid string) (*OvnCommand, error) {
 	}
 	row := make(OVNRow)
 	row["name"] = lr
-	lruuid := odbi.getRowUUID(tableLogicalRouter, row)
+	lruuid := odbi.getRowUUID(TableLogicalRouter, row)
 	if len(lruuid) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -155,7 +155,7 @@ func (odbi *ovndb) lrsrDelByUUIDImp(lr, uuid string) (*OvnCommand, error) {
 	mucondition := libovsdb.NewCondition("name", "==", lr)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalRouter,
+		Table:     TableLogicalRouter,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{mucondition},
 	}
@@ -164,15 +164,15 @@ func (odbi *ovndb) lrsrDelByUUIDImp(lr, uuid string) (*OvnCommand, error) {
 }
 
 func (odbi *ovndb) rowToLogicalRouterStaticRoute(uuid string) *LogicalRouterStaticRoute {
-	cacheLogicalRouterStaticRoute, ok := odbi.cache[tableLogicalRouterStaticRoute][uuid]
+	cacheLogicalRouterStaticRoute, ok := odbi.cache[TableLogicalRouterStaticRoute][uuid]
 	if !ok {
 		return nil
 	}
 	lrsr := &LogicalRouterStaticRoute{
 		UUID:       uuid,
-		IPPrefix:   odbi.cache[tableLogicalRouterStaticRoute][uuid].Fields["ip_prefix"].(string),
-		Nexthop:    odbi.cache[tableLogicalRouterStaticRoute][uuid].Fields["nexthop"].(string),
-		ExternalID: odbi.cache[tableLogicalRouterStaticRoute][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		IPPrefix:   odbi.cache[TableLogicalRouterStaticRoute][uuid].Fields["ip_prefix"].(string),
+		Nexthop:    odbi.cache[TableLogicalRouterStaticRoute][uuid].Fields["nexthop"].(string),
+		ExternalID: odbi.cache[TableLogicalRouterStaticRoute][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
 	}
 
 	if policy, ok := cacheLogicalRouterStaticRoute.Fields["policy"]; ok {
@@ -200,7 +200,7 @@ func (odbi *ovndb) lrsrListImp(lr string) ([]*LogicalRouterStaticRoute, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalRouter, ok := odbi.cache[tableLogicalRouter]
+	cacheLogicalRouter, ok := odbi.cache[TableLogicalRouter]
 	if !ok {
 		return nil, ErrorNotFound
 	}

--- a/logical_switch.go
+++ b/logical_switch.go
@@ -45,13 +45,13 @@ func (odbi *ovndb) lsAddImp(lsw string) (*OvnCommand, error) {
 	lswitch := make(OVNRow)
 	lswitch["name"] = lsw
 
-	if uuid := odbi.getRowUUID(tableLogicalSwitch, lswitch); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TableLogicalSwitch, lswitch); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
 
 	insertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableLogicalSwitch,
+		Table:    TableLogicalSwitch,
 		Row:      lswitch,
 		UUIDName: namedUUID,
 	}
@@ -63,7 +63,7 @@ func (odbi *ovndb) lsDelImp(lsw string) (*OvnCommand, error) {
 	condition := libovsdb.NewCondition("name", "==", lsw)
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tableLogicalSwitch,
+		Table: TableLogicalSwitch,
 		Where: []interface{}{condition},
 	}
 	operations := []libovsdb.Operation{deleteOp}
@@ -71,7 +71,7 @@ func (odbi *ovndb) lsDelImp(lsw string) (*OvnCommand, error) {
 }
 
 func (odbi *ovndb) rowToLogicalSwitch(uuid string) *LogicalSwitch {
-	cacheLogicalSwitch, ok := odbi.cache[tableLogicalSwitch][uuid]
+	cacheLogicalSwitch, ok := odbi.cache[TableLogicalSwitch][uuid]
 	if !ok {
 		return nil
 	}
@@ -131,7 +131,7 @@ func (odbi *ovndb) lsGetImp(ls string) ([]*LogicalSwitch, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalSwitch, ok := odbi.cache[tableLogicalSwitch]
+	cacheLogicalSwitch, ok := odbi.cache[TableLogicalSwitch]
 	if !ok {
 		return nil, ErrorNotFound
 	}
@@ -154,7 +154,7 @@ func (odbi *ovndb) lsListImp() ([]*LogicalSwitch, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalSwitch, ok := odbi.cache[tableLogicalSwitch]
+	cacheLogicalSwitch, ok := odbi.cache[TableLogicalSwitch]
 	if !ok {
 		return nil, ErrorSchema
 	}
@@ -170,7 +170,7 @@ func (odbi *ovndb) lslbAddImp(lswitch string, lb string) (*OvnCommand, error) {
 	var operations []libovsdb.Operation
 	row := make(OVNRow)
 	row["name"] = lb
-	lbuuid := odbi.getRowUUID(tableLoadBalancer, row)
+	lbuuid := odbi.getRowUUID(TableLoadBalancer, row)
 	if len(lbuuid) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -182,14 +182,14 @@ func (odbi *ovndb) lslbAddImp(lswitch string, lb string) (*OvnCommand, error) {
 	}
 	row = make(OVNRow)
 	row["name"] = lswitch
-	lsuuid := odbi.getRowUUID(tableLogicalSwitch, row)
+	lsuuid := odbi.getRowUUID(TableLogicalSwitch, row)
 	if len(lsuuid) == 0 {
 		return nil, ErrorNotFound
 	}
 	condition := libovsdb.NewCondition("name", "==", lswitch)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitch,
+		Table:     TableLogicalSwitch,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -201,13 +201,13 @@ func (odbi *ovndb) lslbDelImp(lswitch string, lb string) (*OvnCommand, error) {
 	var operations []libovsdb.Operation
 	row := make(OVNRow)
 	row["name"] = lb
-	lbuuid := odbi.getRowUUID(tableLoadBalancer, row)
+	lbuuid := odbi.getRowUUID(TableLoadBalancer, row)
 	if len(lbuuid) == 0 {
 		return nil, ErrorNotFound
 	}
 	row = make(OVNRow)
 	row["name"] = lswitch
-	lsuuid := odbi.getRowUUID(tableLogicalSwitch, row)
+	lsuuid := odbi.getRowUUID(TableLogicalSwitch, row)
 	if len(lsuuid) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -221,7 +221,7 @@ func (odbi *ovndb) lslbDelImp(lswitch string, lb string) (*OvnCommand, error) {
 	mucondition := libovsdb.NewCondition("name", "==", lswitch)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitch,
+		Table:     TableLogicalSwitch,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{mucondition},
 	}
@@ -234,7 +234,7 @@ func (odbi *ovndb) lslbListImp(lswitch string) ([]*LoadBalancer, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalSwitch, ok := odbi.cache[tableLogicalSwitch]
+	cacheLogicalSwitch, ok := odbi.cache[TableLogicalSwitch]
 	if !ok {
 		return nil, ErrorSchema
 	}
@@ -286,7 +286,7 @@ func (odbi *ovndb) lsExtIdsAddImp(ls string, external_ids map[string]string) (*O
 	var operations []libovsdb.Operation
 	row := make(OVNRow)
 	row["name"] = ls
-	lsuuid := odbi.getRowUUID(tableLogicalSwitch, row)
+	lsuuid := odbi.getRowUUID(TableLogicalSwitch, row)
 	if len(lsuuid) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -301,7 +301,7 @@ func (odbi *ovndb) lsExtIdsAddImp(ls string, external_ids map[string]string) (*O
 	condition := libovsdb.NewCondition("name", "==", ls)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitch,
+		Table:     TableLogicalSwitch,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -313,7 +313,7 @@ func (odbi *ovndb) lsExtIdsDelImp(ls string, external_ids map[string]string) (*O
 	var operations []libovsdb.Operation
 	row := make(OVNRow)
 	row["name"] = ls
-	lsuuid := odbi.getRowUUID(tableLogicalSwitch, row)
+	lsuuid := odbi.getRowUUID(TableLogicalSwitch, row)
 	if len(lsuuid) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -328,7 +328,7 @@ func (odbi *ovndb) lsExtIdsDelImp(ls string, external_ids map[string]string) (*O
 	condition := libovsdb.NewCondition("name", "==", ls)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitch,
+		Table:     TableLogicalSwitch,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -340,7 +340,7 @@ func (odbi *ovndb) linkSwitchToRouterImp(lsw, lsp, lr, lrp, lrpMac string, netwo
 	// validate logical switch
 	row := make(OVNRow)
 	row["name"] = lsw
-	lswUUID := odbi.getRowUUID(tableLogicalSwitch, row)
+	lswUUID := odbi.getRowUUID(TableLogicalSwitch, row)
 	if len(lswUUID) == 0 {
 		return nil, fmt.Errorf("logical switch %s not found", lsw)
 	}
@@ -353,7 +353,7 @@ func (odbi *ovndb) linkSwitchToRouterImp(lsw, lsp, lr, lrp, lrpMac string, netwo
 	row["name"] = lrp
 	row["mac"] = lrpMac
 	// validate
-	if uuid := odbi.getRowUUID(tableLogicalRouterPort, row); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TableLogicalRouterPort, row); len(uuid) > 0 {
 		return nil, fmt.Errorf("logical router port %s already existed", lrp)
 	}
 	networkSet, err := libovsdb.NewOvsSet(networks)
@@ -370,7 +370,7 @@ func (odbi *ovndb) linkSwitchToRouterImp(lsw, lsp, lr, lrp, lrpMac string, netwo
 	}
 	addLrpOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableLogicalRouterPort,
+		Table:    TableLogicalRouterPort,
 		Row:      row,
 		UUIDName: strLrpUUID,
 	}
@@ -385,7 +385,7 @@ func (odbi *ovndb) linkSwitchToRouterImp(lsw, lsp, lr, lrp, lrpMac string, netwo
 	lrCondition := libovsdb.NewCondition("name", "==", lr)
 	addLrpToLrOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalRouter,
+		Table:     TableLogicalRouter,
 		Mutations: []interface{}{lrPortChange},
 		Where:     []interface{}{lrCondition},
 	}
@@ -403,12 +403,12 @@ func (odbi *ovndb) linkSwitchToRouterImp(lsw, lsp, lr, lrp, lrpMac string, netwo
 	options["router-port"] = lrp
 	optMap, _ := libovsdb.NewOvsMap(options)
 	port["options"] = optMap
-	if uuid := odbi.getRowUUID(tableLogicalSwitchPort, port); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TableLogicalSwitchPort, port); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
 	addLspOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableLogicalSwitchPort,
+		Table:    TableLogicalSwitchPort,
 		Row:      port,
 		UUIDName: strLspUUID,
 	}
@@ -423,7 +423,7 @@ func (odbi *ovndb) linkSwitchToRouterImp(lsw, lsp, lr, lrp, lrpMac string, netwo
 	lsCondition := libovsdb.NewCondition("name", "==", lsw)
 	addLspToLsOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitch,
+		Table:     TableLogicalSwitch,
 		Mutations: []interface{}{lsPortChange},
 		Where:     []interface{}{lsCondition},
 	}

--- a/logical_switch_port.go
+++ b/logical_switch_port.go
@@ -45,13 +45,13 @@ func (odbi *ovndb) lspAddImp(lsw, lsp string) (*OvnCommand, error) {
 	row := make(OVNRow)
 	row["name"] = lsp
 
-	if uuid := odbi.getRowUUID(tableLogicalSwitchPort, row); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TableLogicalSwitchPort, row); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
 
 	insertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableLogicalSwitchPort,
+		Table:    TableLogicalSwitchPort,
 		Row:      row,
 		UUIDName: namedUUID,
 	}
@@ -67,7 +67,7 @@ func (odbi *ovndb) lspAddImp(lsw, lsp string) (*OvnCommand, error) {
 
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitch,
+		Table:     TableLogicalSwitch,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -79,7 +79,7 @@ func (odbi *ovndb) lspDelImp(lsp string) (*OvnCommand, error) {
 	row := make(OVNRow)
 	row["name"] = lsp
 
-	lspUUID := odbi.getRowUUID(tableLogicalSwitchPort, row)
+	lspUUID := odbi.getRowUUID(TableLogicalSwitchPort, row)
 	if len(lspUUID) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -88,7 +88,7 @@ func (odbi *ovndb) lspDelImp(lsp string) (*OvnCommand, error) {
 	condition := libovsdb.NewCondition("name", "==", lsp)
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tableLogicalSwitchPort,
+		Table: TableLogicalSwitchPort,
 		Where: []interface{}{condition},
 	}
 	mutateSet, err := libovsdb.NewOvsSet(mutateUUID)
@@ -96,7 +96,7 @@ func (odbi *ovndb) lspDelImp(lsp string) (*OvnCommand, error) {
 		return nil, err
 	}
 	mutation := libovsdb.NewMutation("ports", opDelete, mutateSet)
-	ucondition, err := odbi.getRowUUIDContainsUUID(tableLogicalSwitch, "ports", lspUUID)
+	ucondition, err := odbi.getRowUUIDContainsUUID(TableLogicalSwitch, "ports", lspUUID)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (odbi *ovndb) lspDelImp(lsp string) (*OvnCommand, error) {
 	// simple mutate operation
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitch,
+		Table:     TableLogicalSwitch,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{mucondition},
 	}
@@ -123,7 +123,7 @@ func (odbi *ovndb) lspSetAddressImp(lsp string, addr ...string) (*OvnCommand, er
 	condition := libovsdb.NewCondition("name", "==", lsp)
 	updateOp := libovsdb.Operation{
 		Op:    opUpdate,
-		Table: tableLogicalSwitchPort,
+		Table: TableLogicalSwitchPort,
 		Row:   row,
 		Where: []interface{}{condition},
 	}
@@ -141,7 +141,7 @@ func (odbi *ovndb) lspSetPortSecurityImp(lsp string, security ...string) (*OvnCo
 	condition := libovsdb.NewCondition("name", "==", lsp)
 	updateOp := libovsdb.Operation{
 		Op:    opUpdate,
-		Table: tableLogicalSwitchPort,
+		Table: TableLogicalSwitchPort,
 		Row:   row,
 		Where: []interface{}{condition},
 	}
@@ -155,7 +155,7 @@ func (odbi *ovndb) lspSetDHCPv4OptionsImp(lsp string, uuid string) (*OvnCommand,
 	condition := libovsdb.NewCondition("name", "==", lsp)
 	updateOp := libovsdb.Operation{
 		Op:    opUpdate,
-		Table: tableLogicalSwitchPort,
+		Table: TableLogicalSwitchPort,
 		Row:   row,
 		Where: []interface{}{condition},
 	}
@@ -176,7 +176,7 @@ func (odbi *ovndb) lspSetDHCPv6OptionsImp(lsp string, options string) (*OvnComma
 	condition := libovsdb.NewCondition("name", "==", lsp)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitchPort,
+		Table:     TableLogicalSwitchPort,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -214,7 +214,7 @@ func (odbi *ovndb) lspSetOptionsImp(lsp string, options map[string]string) (*Ovn
 	// simple mutate operation
 	updateOp := libovsdb.Operation{
 		Op:    opUpdate,
-		Table: tableLogicalSwitchPort,
+		Table: TableLogicalSwitchPort,
 		Row:   row,
 		Where: []interface{}{condition},
 	}
@@ -249,7 +249,7 @@ func (odbi *ovndb) lspSetDynamicAddressesImp(lsp string, address string) (*OvnCo
 	condition := libovsdb.NewCondition("name", "==", lsp)
 	updateOp := libovsdb.Operation{
 		Op:    opUpdate,
-		Table: tableLogicalSwitchPort,
+		Table: TableLogicalSwitchPort,
 		Row:   row,
 		Where: []interface{}{condition},
 	}
@@ -287,7 +287,7 @@ func (odbi *ovndb) lspSetExternalIdsImp(lsp string, external_ids map[string]stri
 	// simple mutate operation
 	updateOp := libovsdb.Operation{
 		Op:    opUpdate,
-		Table: tableLogicalSwitchPort,
+		Table: TableLogicalSwitchPort,
 		Row:   row,
 		Where: []interface{}{condition},
 	}
@@ -315,12 +315,12 @@ func (odbi *ovndb) lspGetExternalIdsImp(lsp string) (map[string]string, error) {
 func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 	lp := &LogicalSwitchPort{
 		UUID:       uuid,
-		Name:       odbi.cache[tableLogicalSwitchPort][uuid].Fields["name"].(string),
-		Type:       odbi.cache[tableLogicalSwitchPort][uuid].Fields["type"].(string),
-		ExternalID: odbi.cache[tableLogicalSwitchPort][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		Name:       odbi.cache[TableLogicalSwitchPort][uuid].Fields["name"].(string),
+		Type:       odbi.cache[TableLogicalSwitchPort][uuid].Fields["type"].(string),
+		ExternalID: odbi.cache[TableLogicalSwitchPort][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
 	}
 
-	if dhcpv4, ok := odbi.cache[tableLogicalSwitchPort][uuid].Fields["dhcpv4_options"]; ok {
+	if dhcpv4, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["dhcpv4_options"]; ok {
 		switch dhcpv4.(type) {
 		case libovsdb.UUID:
 			lp.DHCPv4Options = dhcpv4.(libovsdb.UUID).GoUUID
@@ -328,7 +328,7 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		default:
 		}
 	}
-	if dhcpv6, ok := odbi.cache[tableLogicalSwitchPort][uuid].Fields["dhcpv6_options"]; ok {
+	if dhcpv6, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["dhcpv6_options"]; ok {
 		switch dhcpv6.(type) {
 		case libovsdb.UUID:
 			lp.DHCPv6Options = dhcpv6.(libovsdb.UUID).GoUUID
@@ -337,7 +337,7 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		}
 	}
 
-	if addr, ok := odbi.cache[tableLogicalSwitchPort][uuid].Fields["addresses"]; ok {
+	if addr, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["addresses"]; ok {
 		switch addr.(type) {
 		case string:
 			lp.Addresses = []string{addr.(string)}
@@ -348,7 +348,7 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		}
 	}
 
-	if portsecurity, ok := odbi.cache[tableLogicalSwitchPort][uuid].Fields["port_security"]; ok {
+	if portsecurity, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["port_security"]; ok {
 		switch portsecurity.(type) {
 		case string:
 			lp.PortSecurity = []string{portsecurity.(string)}
@@ -359,11 +359,11 @@ func (odbi *ovndb) rowToLogicalPort(uuid string) (*LogicalSwitchPort, error) {
 		}
 	}
 
-	if options, ok := odbi.cache[tableLogicalSwitchPort][uuid].Fields["options"]; ok {
+	if options, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["options"]; ok {
 		lp.Options = options.(libovsdb.OvsMap).GoMap
 	}
 
-	if dynamicAddresses, ok := odbi.cache[tableLogicalSwitchPort][uuid].Fields["dynamic_addresses"]; ok {
+	if dynamicAddresses, ok := odbi.cache[TableLogicalSwitchPort][uuid].Fields["dynamic_addresses"]; ok {
 		switch dynamicAddresses.(type) {
 		case string:
 			lp.DynamicAddresses = dynamicAddresses.(string)
@@ -382,7 +382,7 @@ func (odbi *ovndb) lspGetImp(lsp string) (*LogicalSwitchPort, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalSwitchPort, ok := odbi.cache[tableLogicalSwitchPort]
+	cacheLogicalSwitchPort, ok := odbi.cache[TableLogicalSwitchPort]
 	if !ok {
 		return nil, ErrorSchema
 	}
@@ -402,7 +402,7 @@ func (odbi *ovndb) lspListImp(lsw string) ([]*LogicalSwitchPort, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalSwitch, ok := odbi.cache[tableLogicalSwitch]
+	cacheLogicalSwitch, ok := odbi.cache[TableLogicalSwitch]
 	if !ok {
 		return nil, ErrorSchema
 	}

--- a/meter.go
+++ b/meter.go
@@ -24,7 +24,7 @@ type MeterBand struct {
 }
 
 func (odbi *ovndb) rowToMeter(uuid string) *Meter {
-	cacheMeter, ok := odbi.cache[tableMeter][uuid]
+	cacheMeter, ok := odbi.cache[TableMeter][uuid]
 	if !ok {
 		return nil
 	}
@@ -39,7 +39,7 @@ func (odbi *ovndb) rowToMeter(uuid string) *Meter {
 }
 
 func (odbi *ovndb) rowToMeterBand(uuid string) (*MeterBand, error) {
-	cacheMeterBand, ok := odbi.cache[tableMeterBand][uuid]
+	cacheMeterBand, ok := odbi.cache[TableMeterBand][uuid]
 	if !ok {
 		return nil, ErrorNotFound
 	}
@@ -78,7 +78,7 @@ func (odbi *ovndb) meterAddImp(name, action string, rate int, unit string, exter
 	mRow := make(OVNRow)
 
 	mRow["name"] = name
-	if uuid := odbi.getRowUUID(tableMeter, mRow); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TableMeter, mRow); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
 
@@ -118,14 +118,14 @@ func (odbi *ovndb) meterAddImp(name, action string, rate int, unit string, exter
 
 	mbInsterOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableMeterBand,
+		Table:    TableMeterBand,
 		Row:      mbRow,
 		UUIDName: MeterBandUUID,
 	}
 
 	mInsertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableMeter,
+		Table:    TableMeter,
 		Row:      mRow,
 		UUIDName: MeterUUID,
 	}
@@ -144,8 +144,8 @@ func (odbi *ovndb) meterDelImp(name ...string) (*OvnCommand, error) {
 
 	switch len(name) {
 	case 0:
-		for uuid := range odbi.cache[tableMeter] {
-			name := odbi.cache[tableMeter][uuid].Fields["name"].(string)
+		for uuid := range odbi.cache[TableMeter] {
+			name := odbi.cache[TableMeter][uuid].Fields["name"].(string)
 			operations, err = odbi.singleMeterDel(name, operations)
 			if err != nil {
 				return nil, err
@@ -170,7 +170,7 @@ func (odbi *ovndb) meterListImp() ([]*Meter, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 	var ListMeter []*Meter
-	cacheMeter, ok := odbi.cache[tableMeter]
+	cacheMeter, ok := odbi.cache[TableMeter]
 	if !ok {
 		return nil, ErrorNotFound
 	}
@@ -185,7 +185,7 @@ func (odbi *ovndb) meterBandsListImp() ([]*MeterBand, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 	var ListMeterBands []*MeterBand
-	cacheMeterBands, ok := odbi.cache[tableMeterBand]
+	cacheMeterBands, ok := odbi.cache[TableMeterBand]
 	if !ok {
 		return nil, ErrorNotFound
 	}
@@ -204,7 +204,7 @@ func (odbi *ovndb) meterFind(name string) bool {
 	defer odbi.cachemutex.RUnlock()
 	row := make(OVNRow)
 	row["name"] = name
-	meterUUID := odbi.getRowUUID(tableMeter, row)
+	meterUUID := odbi.getRowUUID(TableMeter, row)
 	if len(meterUUID) == 0 {
 		return false
 	}
@@ -215,22 +215,22 @@ func (odbi *ovndb) singleMeterDel(name string, operations []libovsdb.Operation) 
 	meterName := name
 	row := make(OVNRow)
 	row["name"] = meterName
-	meterUUID := odbi.getRowUUID(tableMeter, row)
+	meterUUID := odbi.getRowUUID(TableMeter, row)
 	if len(meterUUID) == 0 {
 		return nil, ErrorNotFound
 	}
-	bands := odbi.cache[tableMeter][meterUUID].Fields["bands"].(libovsdb.UUID)
+	bands := odbi.cache[TableMeter][meterUUID].Fields["bands"].(libovsdb.UUID)
 	mCondition := libovsdb.NewCondition("name", "==", meterName)
 	mDeleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tableMeter,
+		Table: TableMeter,
 		Where: []interface{}{mCondition},
 	}
 
 	bCondition := libovsdb.NewCondition("_uuid", "==", bands)
 	bDeleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tableMeterBand,
+		Table: TableMeterBand,
 		Where: []interface{}{bCondition},
 	}
 	operations = append(operations, bDeleteOp)

--- a/nat.go
+++ b/nat.go
@@ -32,7 +32,7 @@ type NAT struct {
 }
 
 func (odbi *ovndb) rowToNat(uuid string) *NAT {
-	cacheNAT, ok := odbi.cache[tableNAT][uuid]
+	cacheNAT, ok := odbi.cache[TableNAT][uuid]
 	if !ok {
 		return nil
 	}
@@ -89,7 +89,7 @@ func (odbi *ovndb) lrNatAddImp(lr string, ntype string, externalIp string, logic
 		return nil, ErrorOption
 	}
 
-	if uuid := odbi.getRowUUID(tableNAT, row); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TableNAT, row); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
 
@@ -117,7 +117,7 @@ func (odbi *ovndb) lrNatAddImp(lr string, ntype string, externalIp string, logic
 
 	insertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableNAT,
+		Table:    TableNAT,
 		Row:      row,
 		UUIDName: nameUUID,
 	}
@@ -132,7 +132,7 @@ func (odbi *ovndb) lrNatAddImp(lr string, ntype string, externalIp string, logic
 	condition := libovsdb.NewCondition("name", "==", lr)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalRouter,
+		Table:     TableLogicalRouter,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -174,7 +174,7 @@ func (odbi *ovndb) lrNatDelImp(lr string, ntype string, ip ...string) (*OvnComma
 		return nil, ErrorOption
 	}
 
-	lrNatUUID := odbi.getRowUUIDs(tableNAT, row)
+	lrNatUUID := odbi.getRowUUIDs(TableNAT, row)
 	if len(lrNatUUID) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -208,7 +208,7 @@ func (odbi *ovndb) lrNatDelImp(lr string, ntype string, ip ...string) (*OvnComma
 		return nil, err
 	}
 
-	lrNatUUID = odbi.getRowUUIDs(tableNAT, row)
+	lrNatUUID = odbi.getRowUUIDs(TableNAT, row)
 	if len(lrNatUUID) == 0 {
 		return nil, ErrorNotFound
 	}
@@ -219,7 +219,7 @@ func (odbi *ovndb) lrNatDelImp(lr string, ntype string, ip ...string) (*OvnComma
 	mucondition := libovsdb.NewCondition("name", "==", lr)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalRouter,
+		Table:     TableLogicalRouter,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{mucondition},
 	}

--- a/nb_global.go
+++ b/nb_global.go
@@ -26,20 +26,20 @@ type NBGlobalTableRow struct {
 }
 
 func (odbi *ovndb) nbGlobalAddImp(options map[string]string) (*OvnCommand, error) {
-	return odbi.addGlobalTableRowImp(options, tableNBGlobal)
+	return odbi.addGlobalTableRowImp(options, TableNBGlobal)
 }
 
 func (odbi *ovndb) nbGlobalDelImp() (*OvnCommand, error) {
-	return odbi.delGlobalTableRowImp(tableNBGlobal)
+	return odbi.delGlobalTableRowImp(TableNBGlobal)
 }
 
 // ovsdb-client -v transact '["Open_vSwitch", {"op" : "update", "table" : "NB_Global", "where": [["_uuid", "==", ["uuid", "587c6ee2-93f9-4bd8-9794-f4a983d139a4"]]],
 // "row":{ "options" : [ "map", [[ "bar", "baz"],["engine_test", "engine-foo"]]],}}]'
 
 func (odbi *ovndb) nbGlobalSetOptionsImp(options map[string]string) (*OvnCommand, error) {
-	return odbi.globalSetOptionsImp(options, tableNBGlobal)
+	return odbi.globalSetOptionsImp(options, TableNBGlobal)
 }
 
 func (odbi *ovndb) nbGlobalGetOptionsImp() (map[string]string, error) {
-	return odbi.globalGetOptionsImp(tableNBGlobal)
+	return odbi.globalGetOptionsImp(TableNBGlobal)
 }

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -233,45 +233,45 @@ func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 
 				if odbi.signalCB != nil {
 					switch table {
-					case tableLogicalRouter:
+					case TableLogicalRouter:
 						lr := odbi.rowToLogicalRouter(uuid)
 						odbi.signalCB.OnLogicalRouterCreate(lr)
-					case tableLogicalRouterPort:
+					case TableLogicalRouterPort:
 						lrp := odbi.rowToLogicalRouterPort(uuid)
 						odbi.signalCB.OnLogicalRouterPortCreate(lrp)
-					case tableLogicalRouterStaticRoute:
+					case TableLogicalRouterStaticRoute:
 						lrsr := odbi.rowToLogicalRouterStaticRoute(uuid)
 						odbi.signalCB.OnLogicalRouterStaticRouteCreate(lrsr)
-					case tableLogicalSwitch:
+					case TableLogicalSwitch:
 						ls := odbi.rowToLogicalSwitch(uuid)
 						odbi.signalCB.OnLogicalSwitchCreate(ls)
-					case tableLogicalSwitchPort:
+					case TableLogicalSwitchPort:
 						lp, err := odbi.rowToLogicalPort(uuid)
 						if err == nil {
 							odbi.signalCB.OnLogicalPortCreate(lp)
 						}
-					case tableACL:
+					case TableACL:
 						acl := odbi.rowToACL(uuid)
 						odbi.signalCB.OnACLCreate(acl)
-					case tableDHCPOptions:
+					case TableDHCPOptions:
 						dhcp := odbi.rowToDHCPOptions(uuid)
 						odbi.signalCB.OnDHCPOptionsCreate(dhcp)
-					case tableQoS:
+					case TableQoS:
 						qos := odbi.rowToQoS(uuid)
 						odbi.signalCB.OnQoSCreate(qos)
-					case tableLoadBalancer:
+					case TableLoadBalancer:
 						lb, _ := odbi.rowToLB(uuid)
 						odbi.signalCB.OnLoadBalancerCreate(lb)
-					case tableMeter:
+					case TableMeter:
 						meter := odbi.rowToMeter(uuid)
 						odbi.signalCB.onMeterCreate(meter)
-					case tableMeterBand:
+					case TableMeterBand:
 						band, _ := odbi.rowToMeterBand(uuid)
 						odbi.signalCB.onMeterBandCreate(band)
-					case tableChassis:
+					case TableChassis:
 						chassis, _ := odbi.rowToChassis(uuid)
 						odbi.signalCB.onChassisCreate(chassis)
-					case tableEncap:
+					case TableEncap:
 						encap, _ := odbi.rowToEncap(uuid)
 						odbi.signalCB.onEncapCreate(encap)
 					}
@@ -282,45 +282,45 @@ func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 				if odbi.signalCB != nil {
 					defer func(table, uuid string) {
 						switch table {
-						case tableLogicalRouter:
+						case TableLogicalRouter:
 							lr := odbi.rowToLogicalRouter(uuid)
 							odbi.signalCB.OnLogicalRouterDelete(lr)
-						case tableLogicalRouterPort:
+						case TableLogicalRouterPort:
 							lrp := odbi.rowToLogicalRouterPort(uuid)
 							odbi.signalCB.OnLogicalRouterPortDelete(lrp)
-						case tableLogicalRouterStaticRoute:
+						case TableLogicalRouterStaticRoute:
 							lrsr := odbi.rowToLogicalRouterStaticRoute(uuid)
 							odbi.signalCB.OnLogicalRouterStaticRouteDelete(lrsr)
-						case tableLogicalSwitch:
+						case TableLogicalSwitch:
 							ls := odbi.rowToLogicalSwitch(uuid)
 							odbi.signalCB.OnLogicalSwitchDelete(ls)
-						case tableLogicalSwitchPort:
+						case TableLogicalSwitchPort:
 							lp, err := odbi.rowToLogicalPort(uuid)
 							if err == nil {
 								odbi.signalCB.OnLogicalPortDelete(lp)
 							}
-						case tableACL:
+						case TableACL:
 							acl := odbi.rowToACL(uuid)
 							odbi.signalCB.OnACLDelete(acl)
-						case tableDHCPOptions:
+						case TableDHCPOptions:
 							dhcp := odbi.rowToDHCPOptions(uuid)
 							odbi.signalCB.OnDHCPOptionsDelete(dhcp)
-						case tableQoS:
+						case TableQoS:
 							qos := odbi.rowToQoS(uuid)
 							odbi.signalCB.OnQoSDelete(qos)
-						case tableLoadBalancer:
+						case TableLoadBalancer:
 							lb, _ := odbi.rowToLB(uuid)
 							odbi.signalCB.OnLoadBalancerDelete(lb)
-						case tableMeter:
+						case TableMeter:
 							meter := odbi.rowToMeter(uuid)
 							odbi.signalCB.onMeterDelete(meter)
-						case tableMeterBand:
+						case TableMeterBand:
 							band, _ := odbi.rowToMeterBand(uuid)
 							odbi.signalCB.onMeterBandDelete(band)
-						case tableChassis:
+						case TableChassis:
 							chassis, _ := odbi.rowToChassis(uuid)
 							odbi.signalCB.onChassisDelete(chassis)
-						case tableEncap:
+						case TableEncap:
 							encap, _ := odbi.rowToEncap(uuid)
 							odbi.signalCB.onEncapDelete(encap)
 						}

--- a/port_group.go
+++ b/port_group.go
@@ -40,7 +40,7 @@ func (odbi *ovndb) pgAddImp(group string, ports []string, external_ids map[strin
 	row := make(OVNRow)
 	row["name"] = group
 
-	if uuid := odbi.getRowUUID(tablePortGroup, row); len(uuid) > 0 {
+	if uuid := odbi.getRowUUID(TablePortGroup, row); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
 	pgports, err := libovsdb.NewOvsSet(ports)
@@ -58,7 +58,7 @@ func (odbi *ovndb) pgAddImp(group string, ports []string, external_ids map[strin
 
 	insertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tablePortGroup,
+		Table:    TablePortGroup,
 		Row:      row,
 		UUIDName: namedUUID,
 	}
@@ -70,7 +70,7 @@ func (odbi *ovndb) pgSetPortsImp(group string, ports []string, external_ids map[
 	row := make(OVNRow)
 	row["name"] = group
 
-	if uuid := odbi.getRowUUID(tablePortGroup, row); len(uuid) == 0 {
+	if uuid := odbi.getRowUUID(TablePortGroup, row); len(uuid) == 0 {
 		return nil, ErrorNotFound
 	}
 	pgports, err := libovsdb.NewOvsSet(ports)
@@ -89,7 +89,7 @@ func (odbi *ovndb) pgSetPortsImp(group string, ports []string, external_ids map[
 	condition := libovsdb.NewCondition("name", "==", group)
 	updateOp := libovsdb.Operation{
 		Op:    opUpdate,
-		Table: tablePortGroup,
+		Table: TablePortGroup,
 		Row:   row,
 		Where: []interface{}{condition},
 	}
@@ -102,7 +102,7 @@ func (odbi *ovndb) pgDelImp(group string) (*OvnCommand, error) {
 	condition := libovsdb.NewCondition("name", "==", group)
 	deleteOp := libovsdb.Operation{
 		Op:    opDelete,
-		Table: tablePortGroup,
+		Table: TablePortGroup,
 		Where: []interface{}{condition},
 	}
 	operations := []libovsdb.Operation{deleteOp}
@@ -112,17 +112,17 @@ func (odbi *ovndb) pgDelImp(group string) (*OvnCommand, error) {
 func (odbi *ovndb) RowToPortGroup(uuid string) *PortGroup {
 	pg := &PortGroup{
 		UUID:       uuid,
-		Name:       odbi.cache[tablePortGroup][uuid].Fields["name"].(string),
-		ExternalID: odbi.cache[tablePortGroup][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		Name:       odbi.cache[TablePortGroup][uuid].Fields["name"].(string),
+		ExternalID: odbi.cache[TablePortGroup][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
 	}
-	ports := odbi.cache[tablePortGroup][uuid].Fields["ports"]
+	ports := odbi.cache[TablePortGroup][uuid].Fields["ports"]
 	switch ports.(type) {
 	case string:
 		pg.Ports = []string{ports.(string)}
 	case libovsdb.OvsSet:
 		pg.Ports = odbi.ConvertGoSetToStringArray(ports.(libovsdb.OvsSet))
 	}
-	acls := odbi.cache[tablePortGroup][uuid].Fields["acls"]
+	acls := odbi.cache[TablePortGroup][uuid].Fields["acls"]
 	switch acls.(type) {
 	case string:
 		pg.ACLs = []string{acls.(string)}
@@ -138,7 +138,7 @@ func (odbi *ovndb) GetLogicalPortsByPortGroup(group string) ([]*LogicalSwitchPor
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cachePortGroup, ok := odbi.cache[tablePortGroup]
+	cachePortGroup, ok := odbi.cache[TablePortGroup]
 	if !ok {
 		return nil, ErrorSchema
 	}

--- a/qos.go
+++ b/qos.go
@@ -35,7 +35,7 @@ type QoS struct {
 }
 
 func (odbi *ovndb) rowToQoS(uuid string) *QoS {
-	cacheQoS, ok := odbi.cache[tableQoS][uuid]
+	cacheQoS, ok := odbi.cache[TableQoS][uuid]
 	if !ok {
 		return nil
 	}
@@ -88,7 +88,7 @@ func (odbi *ovndb) qosAddImp(ls string, direction string, priority int, match st
 
 	insertOp := libovsdb.Operation{
 		Op:       opInsert,
-		Table:    tableQoS,
+		Table:    TableQoS,
 		Row:      row,
 		UUIDName: namedUUID,
 	}
@@ -104,7 +104,7 @@ func (odbi *ovndb) qosAddImp(ls string, direction string, priority int, match st
 
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitch,
+		Table:     TableLogicalSwitch,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -128,7 +128,7 @@ func (odbi *ovndb) qosDelImp(ls string, direction string, priority int, match st
 		row["match"] = match
 	}
 
-	selUUIDs := odbi.getRowUUIDs(tableQoS, row)
+	selUUIDs := odbi.getRowUUIDs(TableQoS, row)
 	if len(selUUIDs) == 0 && !reflect.DeepEqual(row, make(OVNRow)) {
 		return nil, ErrorNotFound
 	}
@@ -163,7 +163,7 @@ func (odbi *ovndb) qosDelImp(ls string, direction string, priority int, match st
 	condition := libovsdb.NewCondition("name", "==", ls)
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     tableLogicalSwitch,
+		Table:     TableLogicalSwitch,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -178,7 +178,7 @@ func (odbi *ovndb) qosListImp(ls string) ([]*QoS, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalSwitch, ok := odbi.cache[tableLogicalSwitch]
+	cacheLogicalSwitch, ok := odbi.cache[TableLogicalSwitch]
 	if !ok {
 		return nil, ErrorNotFound
 	}

--- a/sb_global.go
+++ b/sb_global.go
@@ -26,20 +26,20 @@ type SBGlobalTableRow struct {
 }
 
 func (odbi *ovndb) sbGlobalAddImp(options map[string]string) (*OvnCommand, error) {
-	return odbi.addGlobalTableRowImp(options, tableSBGlobal)
+	return odbi.addGlobalTableRowImp(options, TableSBGlobal)
 }
 
 func (odbi *ovndb) sbGlobalDelImp() (*OvnCommand, error) {
-	return odbi.delGlobalTableRowImp(tableSBGlobal)
+	return odbi.delGlobalTableRowImp(TableSBGlobal)
 }
 
 // ovsdb-client -v transact '["Open_vSwitch", {"op" : "update", "table" : "SB_Global", "where": [["_uuid", "==", ["uuid", "587c6ee2-93f9-4bd8-9794-f4a983d139a4"]]],
 // "row":{ "options" : [ "map", [[ "bar", "baz"],["engine_test", "engine-foo"]]],}}]'
 
 func (odbi *ovndb) sbGlobalSetOptionsImp(options map[string]string) (*OvnCommand, error) {
-	return odbi.globalSetOptionsImp(options, tableSBGlobal)
+	return odbi.globalSetOptionsImp(options, TableSBGlobal)
 }
 
 func (odbi *ovndb) sbGlobalGetOptionsImp() (map[string]string, error) {
-	return odbi.globalGetOptionsImp(tableSBGlobal)
+	return odbi.globalGetOptionsImp(TableSBGlobal)
 }


### PR DESCRIPTION
Since clients can watch on specific nb/sb tables, client can re-use
those table constants from go-ovn directly.
Hence, using upper case for tables to make those identifiers exportable.