### PR TITLE
stop the ticker to release associated resources

### DIFF
--- a/client.go
+++ b/client.go
@@ -293,7 +293,8 @@ func (c *ovndb) reconnect() {
 				retry++
 				continue
 			}
-			log.Printf("%s reconnected.\n", c.addr)
+			log.Printf("%s reconnected after %d retries.\n", c.addr, retry)
+			ticker.Stop()
 			return
 		}
 	}()


### PR DESCRIPTION
we weren't stopping the ticker once its job was done in reconnect(),
this commit fixes that issue

@noah8713 @hzhou8 @vtolstov PTAL