### PR TITLE
GoSet could have not just strings but also set of uuids

### DIFF
--- a/logical_router_static_route.go
+++ b/logical_router_static_route.go
@@ -177,16 +177,16 @@ func (odbi *ovndb) rowToLogicalRouterStaticRoute(uuid string) *LogicalRouterStat
 
 	if policy, ok := cacheLogicalRouterStaticRoute.Fields["policy"]; ok {
 		switch policy.(type) {
-		case libovsdb.UUID:
-			lrsr.Policy = []string{policy.(libovsdb.UUID).GoUUID}
+		case string:
+			lrsr.Policy = []string{policy.(string)}
 		case libovsdb.OvsSet:
 			lrsr.Policy = odbi.ConvertGoSetToStringArray(policy.(libovsdb.OvsSet))
 		}
 	}
 	if outputPort, ok := cacheLogicalRouterStaticRoute.Fields["output_port"]; ok {
 		switch outputPort.(type) {
-		case libovsdb.UUID:
-			lrsr.OutputPort = []string{outputPort.(libovsdb.UUID).GoUUID}
+		case string:
+			lrsr.OutputPort = []string{outputPort.(string)}
 		case libovsdb.OvsSet:
 			lrsr.OutputPort = odbi.ConvertGoSetToStringArray(outputPort.(libovsdb.OvsSet))
 		}

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -334,9 +334,13 @@ func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 func (odbi *ovndb) ConvertGoSetToStringArray(oset libovsdb.OvsSet) []string {
 	var ret = []string{}
 	for _, s := range oset.GoSet {
-		value, ok := s.(string)
-		if ok {
+		switch s.(type) {
+		case string:
+			value := s.(string)
 			ret = append(ret, value)
+		case libovsdb.UUID:
+			uuid := s.(libovsdb.UUID)
+			ret = append(ret, uuid.GoUUID)
 		}
 	}
 	return ret


### PR DESCRIPTION
This PR fixes following issues:

- fix logical_router_static_route table's column type assumption

  the code currently assumes that the policy and output_port columns of
logical_router_static_route table to be of type UUID, however it is
of type string

- GoSet could have not just strings but also set of uuids

   the current ConvertGoSetToStringArray() API assumes that the GoSet
consists of only strings but it could also contain set of UUIDs (for
example logical_switch`ports column).

