### PR TITLE
fix incorrect column type assumptions in chassis and port_group table

### DIFF
--- a/chassis.go
+++ b/chassis.go
@@ -191,16 +191,16 @@ func (odbi *ovndb) rowToChassis(uuid string) (*Chassis, error) {
 
 	if tz, ok := cacheChassis.Fields["transport_zones"]; ok {
 		switch tz.(type) {
-		case libovsdb.UUID:
-			ch.TransportZones = []string{tz.(libovsdb.UUID).GoUUID}
+		case string:
+			ch.TransportZones = []string{tz.(string)}
 		case libovsdb.OvsSet:
 			ch.TransportZones = odbi.ConvertGoSetToStringArray(tz.(libovsdb.OvsSet))
 		}
 	}
 	if vtep, ok := cacheChassis.Fields["vtep_logical_switches"]; ok {
 		switch vtep.(type) {
-		case libovsdb.UUID:
-			ch.VtepLogicalSwitches = []string{vtep.(libovsdb.UUID).GoUUID}
+		case string:
+			ch.VtepLogicalSwitches = []string{vtep.(string)}
 		case libovsdb.OvsSet:
 			ch.VtepLogicalSwitches = odbi.ConvertGoSetToStringArray(vtep.(libovsdb.OvsSet))
 		}

--- a/port_group.go
+++ b/port_group.go
@@ -117,15 +117,15 @@ func (odbi *ovndb) RowToPortGroup(uuid string) *PortGroup {
 	}
 	ports := odbi.cache[TablePortGroup][uuid].Fields["ports"]
 	switch ports.(type) {
-	case string:
-		pg.Ports = []string{ports.(string)}
+	case libovsdb.UUID:
+		pg.Ports = []string{ports.(libovsdb.UUID).GoUUID}
 	case libovsdb.OvsSet:
 		pg.Ports = odbi.ConvertGoSetToStringArray(ports.(libovsdb.OvsSet))
 	}
 	acls := odbi.cache[TablePortGroup][uuid].Fields["acls"]
 	switch acls.(type) {
-	case string:
-		pg.ACLs = []string{acls.(string)}
+	case libovsdb.UUID:
+		pg.ACLs = []string{acls.(libovsdb.UUID).GoUUID}
 	case libovsdb.OvsSet:
 		pg.ACLs = odbi.ConvertGoSetToStringArray(acls.(libovsdb.OvsSet))
 	}


### PR DESCRIPTION
chassis' transport_zones and vtep_logical_switches are of type string
port_gruop's ports and acls are of type UUIDs

@hzhou8 @noah8713 @vtolstov PTAL