### PR TITLE
Fix LogicalRouterStaticRoute related APIs

### DIFF
--- a/client.go
+++ b/client.go
@@ -100,7 +100,7 @@ type Client interface {
 	LRPList(lr string) ([]*LogicalRouterPort, error)
 
 	// Add LRSR with given ip_prefix on given lr
-	LRSRAdd(lr string, ip_prefix string, nexthop string, output_port []string, policy []string, external_ids map[string]string) (*OvnCommand, error)
+	LRSRAdd(lr string, ip_prefix string, nexthop string, output_port *string, policy *string, external_ids map[string]string) (*OvnCommand, error)
 	// Delete LRSR with given ip_prefix, nexthop, outputPort and policy on given lr
 	LRSRDel(lr string, prefix string, nexthop, outputPort, policy *string) (*OvnCommand, error)
 	// Delete LRSR by uuid given lr
@@ -495,7 +495,7 @@ func (c *ovndb) LRPList(lr string) ([]*LogicalRouterPort, error) {
 	return c.lrpListImp(lr)
 }
 
-func (c *ovndb) LRSRAdd(lr string, ip_prefix string, nexthop string, output_port []string, policy []string, external_ids map[string]string) (*OvnCommand, error) {
+func (c *ovndb) LRSRAdd(lr string, ip_prefix string, nexthop string, output_port *string, policy *string, external_ids map[string]string) (*OvnCommand, error) {
 	return c.lrsrAddImp(lr, ip_prefix, nexthop, output_port, policy, external_ids)
 }
 

--- a/client.go
+++ b/client.go
@@ -101,8 +101,8 @@ type Client interface {
 
 	// Add LRSR with given ip_prefix on given lr
 	LRSRAdd(lr string, ip_prefix string, nexthop string, output_port []string, policy []string, external_ids map[string]string) (*OvnCommand, error)
-	// Delete LRSR with given ip_prefix, nexthop, policy and outputPort on given lr
-	LRSRDel(lr string, prefix string, nexthop, policy, outputPort *string) (*OvnCommand, error)
+	// Delete LRSR with given ip_prefix, nexthop, outputPort and policy on given lr
+	LRSRDel(lr string, prefix string, nexthop, outputPort, policy *string) (*OvnCommand, error)
 	// Delete LRSR by uuid given lr
 	LRSRDelByUUID(lr, uuid string) (*OvnCommand, error)
 	// Get all LRSRs by lr
@@ -499,8 +499,8 @@ func (c *ovndb) LRSRAdd(lr string, ip_prefix string, nexthop string, output_port
 	return c.lrsrAddImp(lr, ip_prefix, nexthop, output_port, policy, external_ids)
 }
 
-func (c *ovndb) LRSRDel(lr string, prefix string, nexthop, policy, outputPort *string) (*OvnCommand, error) {
-	return c.lrsrDelImp(lr, prefix, nexthop, policy, outputPort)
+func (c *ovndb) LRSRDel(lr string, prefix string, nexthop, outputPort, policy *string) (*OvnCommand, error) {
+	return c.lrsrDelImp(lr, prefix, nexthop, outputPort, policy)
 }
 
 func (c *ovndb) LRSRDelByUUID(lr, uuid string) (*OvnCommand, error) {

--- a/logical_router_static_route.go
+++ b/logical_router_static_route.go
@@ -42,10 +42,10 @@ func (odbi *ovndb) lrsrAddImp(lr string, ip_prefix string, nexthop string, outpu
 	row["ip_prefix"] = ip_prefix
 	row["nexthop"] = nexthop
 	if len(output_port) > 0 {
-		row["output_port"] = output_port
+		row["output_port"] = output_port[0]
 	}
 	if len(policy) > 0 {
-		row["policies"] = policy
+		row["policy"] = policy[0]
 	}
 	if external_ids != nil {
 		oMap, err := libovsdb.NewOvsMap(external_ids)
@@ -99,10 +99,10 @@ func (odbi *ovndb) lrsrDelImp(lr string, prefix string, nexthop, policy, outputP
 		row["nexthop"] = *nexthop
 	}
 	if policy != nil {
-		row["policy"] = []string{*policy}
+		row["policy"] = *policy
 	}
 	if outputPort != nil {
-		row["output_port"] = []string{*outputPort}
+		row["output_port"] = *outputPort
 	}
 	lrsruuid := odbi.getRowUUID(TableLogicalRouterStaticRoute, row)
 	if len(lrsruuid) == 0 {

--- a/logical_router_static_route.go
+++ b/logical_router_static_route.go
@@ -85,7 +85,7 @@ func (odbi *ovndb) lrsrAddImp(lr string, ip_prefix string, nexthop string, outpu
 
 }
 
-func (odbi *ovndb) lrsrDelImp(lr string, prefix string, nexthop, policy, outputPort *string) (*OvnCommand, error) {
+func (odbi *ovndb) lrsrDelImp(lr string, prefix string, nexthop, outputPort, policy *string) (*OvnCommand, error) {
 	if lr == "" {
 		return nil, fmt.Errorf("lr (logical router name) is required")
 	}

--- a/logical_router_static_route.go
+++ b/logical_router_static_route.go
@@ -170,9 +170,9 @@ func (odbi *ovndb) rowToLogicalRouterStaticRoute(uuid string) *LogicalRouterStat
 	}
 	lrsr := &LogicalRouterStaticRoute{
 		UUID:       uuid,
-		IPPrefix:   odbi.cache[TableLogicalRouterStaticRoute][uuid].Fields["ip_prefix"].(string),
-		Nexthop:    odbi.cache[TableLogicalRouterStaticRoute][uuid].Fields["nexthop"].(string),
-		ExternalID: odbi.cache[TableLogicalRouterStaticRoute][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		IPPrefix:   cacheLogicalRouterStaticRoute.Fields["ip_prefix"].(string),
+		Nexthop:    cacheLogicalRouterStaticRoute.Fields["nexthop"].(string),
+		ExternalID: cacheLogicalRouterStaticRoute.Fields["external_ids"].(libovsdb.OvsMap).GoMap,
 	}
 
 	if policy, ok := cacheLogicalRouterStaticRoute.Fields["policy"]; ok {

--- a/logical_router_static_route.go
+++ b/logical_router_static_route.go
@@ -27,12 +27,12 @@ type LogicalRouterStaticRoute struct {
 	UUID       string
 	IPPrefix   string
 	Nexthop    string
-	OutputPort []string
-	Policy     []string
+	OutputPort *string
+	Policy     *string
 	ExternalID map[interface{}]interface{}
 }
 
-func (odbi *ovndb) lrsrAddImp(lr string, ip_prefix string, nexthop string, output_port []string, policy []string, external_ids map[string]string) (*OvnCommand, error) {
+func (odbi *ovndb) lrsrAddImp(lr string, ip_prefix string, nexthop string, output_port *string, policy *string, external_ids map[string]string) (*OvnCommand, error) {
 	namedUUID, err := newRowUUID()
 	if err != nil {
 		return nil, err
@@ -41,11 +41,11 @@ func (odbi *ovndb) lrsrAddImp(lr string, ip_prefix string, nexthop string, outpu
 	row := make(OVNRow)
 	row["ip_prefix"] = ip_prefix
 	row["nexthop"] = nexthop
-	if len(output_port) > 0 {
-		row["output_port"] = output_port[0]
+	if output_port != nil {
+		row["output_port"] = *output_port
 	}
-	if len(policy) > 0 {
-		row["policy"] = policy[0]
+	if policy != nil {
+		row["policy"] = *policy
 	}
 	if external_ids != nil {
 		oMap, err := libovsdb.NewOvsMap(external_ids)
@@ -176,20 +176,10 @@ func (odbi *ovndb) rowToLogicalRouterStaticRoute(uuid string) *LogicalRouterStat
 	}
 
 	if policy, ok := cacheLogicalRouterStaticRoute.Fields["policy"]; ok {
-		switch policy.(type) {
-		case string:
-			lrsr.Policy = []string{policy.(string)}
-		case libovsdb.OvsSet:
-			lrsr.Policy = odbi.ConvertGoSetToStringArray(policy.(libovsdb.OvsSet))
-		}
+		lrsr.Policy = odbi.optionalStringFieldToPointer(policy)
 	}
 	if outputPort, ok := cacheLogicalRouterStaticRoute.Fields["output_port"]; ok {
-		switch outputPort.(type) {
-		case string:
-			lrsr.OutputPort = []string{outputPort.(string)}
-		case libovsdb.OvsSet:
-			lrsr.OutputPort = odbi.ConvertGoSetToStringArray(outputPort.(libovsdb.OvsSet))
-		}
+		lrsr.OutputPort = odbi.optionalStringFieldToPointer(outputPort)
 	}
 	return lrsr
 }

--- a/logical_router_static_route_test.go
+++ b/logical_router_static_route_test.go
@@ -35,7 +35,7 @@ func TestLogicalRouterStaticRoute(t *testing.T) {
 		t.Fatalf("lr not created %v", lrs)
 	}
 
-	//lr string, ip_prefix string, nexthop string, output_port []string, policy []string, external_ids map[string]string
+	//lr string, ip_prefix string, nexthop string, output_port *string, policy *string, external_ids map[string]string
 	cmd, err = ovndbapi.LRSRAdd(LR2, IPPREFIX, NEXTHOP, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -128,7 +128,7 @@ func TestLogicalRouterStaticRoute(t *testing.T) {
 	// Add static route with policy and output_port.
 	outputPort := "lsp1"
 	policy := "src-ip"
-	cmd, err = ovndbapi.LRSRAdd(LR2, IPPREFIX, NEXTHOP, []string{outputPort}, []string{policy}, nil)
+	cmd, err = ovndbapi.LRSRAdd(LR2, IPPREFIX, NEXTHOP, &outputPort, &policy, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,8 +143,8 @@ func TestLogicalRouterStaticRoute(t *testing.T) {
 	if len(lrsr) < 1 {
 		t.Fatalf("Static Route %s using %s with policy %s not created in %s", IPPREFIX, outputPort, policy, LR2)
 	}
-	assert.Equal(t, outputPort, lrsr[0].OutputPort[0])
-	assert.Equal(t, policy, lrsr[0].Policy[0])
+	assert.Equal(t, outputPort, *lrsr[0].OutputPort)
+	assert.Equal(t, policy, *lrsr[0].Policy)
 
 	// Delete the static route with outputPort specified
 	cmd, err = ovndbapi.LRSRDel(LR2, IPPREFIX, nil, &outputPort, nil)

--- a/logical_router_static_route_test.go
+++ b/logical_router_static_route_test.go
@@ -147,7 +147,7 @@ func TestLogicalRouterStaticRoute(t *testing.T) {
 	assert.Equal(t, policy, lrsr[0].Policy[0])
 
 	// Delete the static route with outputPort specified
-	cmd, err = ovndbapi.LRSRDel(LR2, IPPREFIX, nil, nil, &outputPort)
+	cmd, err = ovndbapi.LRSRDel(LR2, IPPREFIX, nil, &outputPort, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -346,6 +346,21 @@ func (odbi *ovndb) ConvertGoSetToStringArray(oset libovsdb.OvsSet) []string {
 	return ret
 }
 
+func (odbi *ovndb) optionalStringFieldToPointer(fieldValue interface{}) *string {
+	switch fieldValue.(type) {
+	case string:
+		temp := fieldValue.(string)
+		return &temp
+	case libovsdb.OvsSet:
+		temp := odbi.ConvertGoSetToStringArray(fieldValue.(libovsdb.OvsSet))
+		if len(temp) > 0 {
+			return &temp[0]
+		}
+		return nil
+	}
+	return nil
+}
+
 func stringToGoUUID(uuid string) libovsdb.UUID {
 	return libovsdb.UUID{GoUUID: uuid}
 }


### PR DESCRIPTION
The APIs LRSRAdd and LRSRDel were broken when output_port and policy parameters were used. Test case was missing this part. The first patches in the PR fix the bug. The latter patches update the API signature to be more straightforward. Although the API signature is changed, it shouldn't create compatibility problem given that the APIs were broken before this PR.