### PR TITLE
Refactor getRowUUIDs()

### DIFF
--- a/ovnimp.go
+++ b/ovnimp.go
@@ -65,18 +65,16 @@ func (odbi *ovndb) getRowUUIDs(table string, row OVNRow) []string {
 			continue
 		}
 
-		found := false
+		isEqual := true
 		for field, value := range row {
 			if v, ok := drows.Fields[field]; ok {
-				if v == value {
-					found = true
-				} else {
-					found = false
+				if v != value {
+					isEqual = false
 					break
 				}
 			}
 		}
-		if found {
+		if isEqual {
 			uuids = append(uuids, uuid)
 		}
 	}


### PR DESCRIPTION
The current logic is correct but a little confusing. The flag is initialized
to false, and flips to true if the *first* column matches which is unnecessary.

Signed-off-by: Han Zhou <hzhou8@ebay.com>