### PR TITLE
Refactor rowToLogicalRouter() and RowToPortGroup()

### DIFF
--- a/logical_router.go
+++ b/logical_router.go
@@ -101,14 +101,18 @@ func (odbi *ovndb) lrGetImp(name string) ([]*LogicalRouter, error) {
 }
 
 func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
+	cacheLogicalRouter, ok := odbi.cache[TableLogicalRouter][uuid]
+	if !ok {
+		return nil
+	}
 	lr := &LogicalRouter{
 		UUID:       uuid,
-		Name:       odbi.cache[TableLogicalRouter][uuid].Fields["name"].(string),
-		Options:    odbi.cache[TableLogicalRouter][uuid].Fields["options"].(libovsdb.OvsMap).GoMap,
-		ExternalID: odbi.cache[TableLogicalRouter][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		Name:       cacheLogicalRouter.Fields["name"].(string),
+		Options:    cacheLogicalRouter.Fields["options"].(libovsdb.OvsMap).GoMap,
+		ExternalID: cacheLogicalRouter.Fields["external_ids"].(libovsdb.OvsMap).GoMap,
 	}
 
-	if enabled, ok := odbi.cache[TableLogicalRouter][uuid].Fields["enabled"]; ok {
+	if enabled, ok := cacheLogicalRouter.Fields["enabled"]; ok {
 		switch enabled.(type) {
 		case bool:
 			lr.Enabled = enabled.(bool)
@@ -120,7 +124,7 @@ func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
 	}
 
 	var lbs []string
-	load_balancer := odbi.cache[TableLogicalRouter][uuid].Fields["load_balancer"]
+	load_balancer := cacheLogicalRouter.Fields["load_balancer"]
 	if load_balancer != nil {
 		switch load_balancer.(type) {
 		case libovsdb.OvsSet:
@@ -143,7 +147,7 @@ func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
 	lr.LoadBalancer = lbs
 
 	var lps []string
-	ports := odbi.cache[TableLogicalRouter][uuid].Fields["ports"]
+	ports := cacheLogicalRouter.Fields["ports"]
 	if ports != nil {
 		switch ports.(type) {
 		case string:
@@ -167,7 +171,7 @@ func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
 	lr.Ports = lps
 
 	var listLRSR []string
-	staticRoutes := odbi.cache[TableLogicalRouter][uuid].Fields["static_routes"]
+	staticRoutes := cacheLogicalRouter.Fields["static_routes"]
 	if staticRoutes != nil {
 		switch staticRoutes.(type) {
 		case libovsdb.OvsSet:
@@ -189,7 +193,7 @@ func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
 	lr.StaticRoutes = listLRSR
 
 	var NATList []string
-	nat := odbi.cache[TableLogicalRouter][uuid].Fields["nat"]
+	nat := cacheLogicalRouter.Fields["nat"]
 	if nat != nil {
 		switch nat.(type) {
 		case libovsdb.OvsSet:

--- a/port_group.go
+++ b/port_group.go
@@ -110,19 +110,23 @@ func (odbi *ovndb) pgDelImp(group string) (*OvnCommand, error) {
 }
 
 func (odbi *ovndb) RowToPortGroup(uuid string) *PortGroup {
+	cachePortGroup, ok := odbi.cache[TablePortGroup][uuid]
+	if !ok {
+		return nil
+	}
 	pg := &PortGroup{
 		UUID:       uuid,
-		Name:       odbi.cache[TablePortGroup][uuid].Fields["name"].(string),
-		ExternalID: odbi.cache[TablePortGroup][uuid].Fields["external_ids"].(libovsdb.OvsMap).GoMap,
+		Name:       cachePortGroup.Fields["name"].(string),
+		ExternalID: cachePortGroup.Fields["external_ids"].(libovsdb.OvsMap).GoMap,
 	}
-	ports := odbi.cache[TablePortGroup][uuid].Fields["ports"]
+	ports := cachePortGroup.Fields["ports"]
 	switch ports.(type) {
 	case libovsdb.UUID:
 		pg.Ports = []string{ports.(libovsdb.UUID).GoUUID}
 	case libovsdb.OvsSet:
 		pg.Ports = odbi.ConvertGoSetToStringArray(ports.(libovsdb.OvsSet))
 	}
-	acls := odbi.cache[TablePortGroup][uuid].Fields["acls"]
+	acls := cachePortGroup.Fields["acls"]
 	switch acls.(type) {
 	case libovsdb.UUID:
 		pg.ACLs = []string{acls.(libovsdb.UUID).GoUUID}


### PR DESCRIPTION
To be consistent and make the code more neat instead of typing
same table name with uuid column.

Signed-off-by: Aliasgar Ginwala <aginwala@ebay.com>