### PR TITLE
add selection_fields to the load balancer 

### DIFF
--- a/client.go
+++ b/client.go
@@ -123,6 +123,8 @@ type Client interface {
 	LBDel(name string) (*OvnCommand, error)
 	// Update existing LB
 	LBUpdate(name string, vipPort string, protocol string, addrs []string) (*OvnCommand, error)
+	// Set selection fields for LB session affinity
+	LBSetSelectionFields(name string, selectionFields string) (*OvnCommand, error)
 
 	// Set dhcp4_options uuid on lsp
 	LSPSetDHCPv4Options(lsp string, options string) (*OvnCommand, error)
@@ -533,6 +535,10 @@ func (c *ovndb) LBUpdate(name string, vipPort string, protocol string, addrs []s
 
 func (c *ovndb) LBDel(name string) (*OvnCommand, error) {
 	return c.lbDelImp(name)
+}
+
+func (c *ovndb) LBSetSelectionFields(name string, selectionFields string) (*OvnCommand, error) {
+	return c.lbSetSelectionFieldsImp(name, selectionFields)
 }
 
 func (c *ovndb) ACLAdd(ls, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter string, severity string) (*OvnCommand, error) {

--- a/load_balancer_test.go
+++ b/load_balancer_test.go
@@ -45,6 +45,15 @@ func TestLoadBalancer(t *testing.T) {
 		t.Fatalf("Updating LB OVN failed with err %v", err)
 	}
 	t.Logf("Updating LB to OVN done")
+	ocmd, err = ovndbapi.LBSetSelectionFields(LB1, "ip_src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ovndbapi.Execute(ocmd)
+	if err != nil {
+		t.Fatalf("Setting LB OVN selection fields failed with err %v", err)
+	}
+	t.Logf("Setting LB selection_fields to OVN done")
 
 	t.Logf("Gettting LB by name")
 	lb, err := ovndbapi.LBGet(LB1)
@@ -53,6 +62,9 @@ func TestLoadBalancer(t *testing.T) {
 	}
 	if len(lb) != 1 {
 		t.Fatalf("err getting lbs, total:%v", len(lb))
+	}
+	if lb[0].selectionFields != "ip_src" {
+		t.Fatalf("err setting lbs selection fields, expected: ip_src received:%v", lb[0].selectionFields)
 	}
 	t.Logf("Lb found:%+v", lb[0])
 


### PR DESCRIPTION
Since OVN version 20.06.0, load balancers have a new column
'selection_fields' that allows to define a set of packet
headers to use while selecting the backend, so that session
affinity can be implemented.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

Fixes: https://github.com/eBay/go-ovn/issues/112