### PR TITLE
ovnsignal: expose all methods as public

### DIFF
--- a/apis.go
+++ b/apis.go
@@ -70,19 +70,19 @@ type OVNSignal interface {
 	OnLoadBalancerCreate(ls *LoadBalancer)
 	OnLoadBalancerDelete(ls *LoadBalancer)
 
-	onMeterCreate(meter *Meter)
-	onMeterDelete(meter *Meter)
+	OnMeterCreate(meter *Meter)
+	OnMeterDelete(meter *Meter)
 
-	onMeterBandCreate(band *MeterBand)
-	onMeterBandDelete(band *MeterBand)
+	OnMeterBandCreate(band *MeterBand)
+	OnMeterBandDelete(band *MeterBand)
 
 	// Create/delete chassis from south bound db
-	onChassisCreate(ch *Chassis)
-	onChassisDelete(ch *Chassis)
+	OnChassisCreate(ch *Chassis)
+	OnChassisDelete(ch *Chassis)
 
 	// Create/delete encap from south bound db
-	onEncapCreate(ch *Encap)
-	onEncapDelete(ch *Encap)
+	OnEncapCreate(ch *Encap)
+	OnEncapDelete(ch *Encap)
 }
 
 // OVNNotifier ovnnb and ovnsb notifier


### PR DESCRIPTION
Fixes the OVNSignal interface to let its all methods to be public. This
is necessary from consumer side to define OVNSignal implementation.