### PR TITLE
Fix panic of rowToLogicalRouter() when SignalCB is registered.

### DIFF
--- a/logical_router.go
+++ b/logical_router.go
@@ -123,96 +123,41 @@ func (odbi *ovndb) rowToLogicalRouter(uuid string) *LogicalRouter {
 		}
 	}
 
-	var lbs []string
-	load_balancer := cacheLogicalRouter.Fields["load_balancer"]
-	if load_balancer != nil {
-		switch load_balancer.(type) {
-		case libovsdb.OvsSet:
-			if lb, ok := load_balancer.(libovsdb.OvsSet); ok {
-				for _, l := range lb.GoSet {
-					if lb, ok := l.(libovsdb.UUID); ok {
-						lb, _ := odbi.rowToLB(lb.GoUUID)
-						lbs = append(lbs, lb.Name)
-					}
-				}
-			}
+	if lbs, ok := cacheLogicalRouter.Fields["load_balancer"]; ok {
+		switch lbs.(type) {
 		case libovsdb.UUID:
-			if lb, ok := load_balancer.(libovsdb.UUID); ok {
-				lb, _ := odbi.rowToLB(lb.GoUUID)
-
-				lbs = append(lbs, lb.Name)
-			}
+			lr.LoadBalancer = []string{lbs.(libovsdb.UUID).GoUUID}
+		case libovsdb.OvsSet:
+			lr.LoadBalancer = odbi.ConvertGoSetToStringArray(lbs.(libovsdb.OvsSet))
 		}
 	}
-	lr.LoadBalancer = lbs
 
-	var lps []string
-	ports := cacheLogicalRouter.Fields["ports"]
-	if ports != nil {
+	if ports, ok := cacheLogicalRouter.Fields["ports"]; ok {
 		switch ports.(type) {
-		case string:
-			lr.Ports = []string{ports.(string)}
-		case libovsdb.OvsSet:
-			if ps, ok := ports.(libovsdb.OvsSet); ok {
-				for _, p := range ps.GoSet {
-					if vp, ok := p.(libovsdb.UUID); ok {
-						tp := odbi.rowToLogicalRouterPort(vp.GoUUID)
-						lps = append(lps, tp.Name)
-					}
-				}
-			}
 		case libovsdb.UUID:
-			if vp, ok := ports.(libovsdb.UUID); ok {
-				tp := odbi.rowToLogicalRouterPort(vp.GoUUID)
-				lps = append(lps, tp.Name)
-			}
+			lr.Ports = []string{ports.(libovsdb.UUID).GoUUID}
+		case libovsdb.OvsSet:
+			lr.Ports = odbi.ConvertGoSetToStringArray(ports.(libovsdb.OvsSet))
 		}
 	}
-	lr.Ports = lps
 
-	var listLRSR []string
-	staticRoutes := cacheLogicalRouter.Fields["static_routes"]
-	if staticRoutes != nil {
-		switch staticRoutes.(type) {
-		case libovsdb.OvsSet:
-			if sr, ok := staticRoutes.(libovsdb.OvsSet); ok {
-				for _, s := range sr.GoSet {
-					if sruid, ok := s.(libovsdb.UUID); ok {
-						rsr := odbi.rowToLogicalRouterStaticRoute(sruid.GoUUID)
-						listLRSR = append(listLRSR, rsr.IPPrefix)
-					}
-				}
-			}
+	if lrsrs, ok := cacheLogicalRouter.Fields["static_routes"]; ok {
+		switch lrsrs.(type) {
 		case libovsdb.UUID:
-			if sruid, ok := staticRoutes.(libovsdb.UUID); ok {
-				rsr := odbi.rowToLogicalRouterStaticRoute(sruid.GoUUID)
-				listLRSR = append(listLRSR, rsr.IPPrefix)
-			}
+			lr.StaticRoutes = []string{lrsrs.(libovsdb.UUID).GoUUID}
+		case libovsdb.OvsSet:
+			lr.StaticRoutes = odbi.ConvertGoSetToStringArray(lrsrs.(libovsdb.OvsSet))
 		}
 	}
-	lr.StaticRoutes = listLRSR
 
-	var NATList []string
-	nat := cacheLogicalRouter.Fields["nat"]
-	if nat != nil {
-		switch nat.(type) {
-		case libovsdb.OvsSet:
-			if sr, ok := nat.(libovsdb.OvsSet); ok {
-				for _, s := range sr.GoSet {
-					if sruid, ok := s.(libovsdb.UUID); ok {
-						rsr := odbi.rowToNat(sruid.GoUUID)
-						NATList = append(NATList, rsr.UUID)
-					}
-				}
-			}
+	if nats, ok := cacheLogicalRouter.Fields["nat"]; ok {
+		switch nats.(type) {
 		case libovsdb.UUID:
-			if sruid, ok := nat.(libovsdb.UUID); ok {
-				rsr := odbi.rowToNat(sruid.GoUUID)
-				NATList = append(NATList, rsr.UUID)
-			}
+			lr.NAT = []string{nats.(libovsdb.UUID).GoUUID}
+		case libovsdb.OvsSet:
+			lr.NAT = odbi.ConvertGoSetToStringArray(nats.(libovsdb.OvsSet))
 		}
 	}
-	lr.NAT = NATList
 
 	return lr
 }

--- a/test_common.go
+++ b/test_common.go
@@ -53,6 +53,49 @@ var (
 	ovn_socket string
 )
 
+type signal struct{}
+
+func (s signal) OnLogicalSwitchCreate(ls *LogicalSwitch) {}
+func (s signal) OnLogicalSwitchDelete(ls *LogicalSwitch) {}
+
+func (s signal) OnLogicalPortCreate(lp *LogicalSwitchPort) {}
+func (s signal) OnLogicalPortDelete(lp *LogicalSwitchPort) {}
+
+func (s signal) OnLogicalRouterCreate(lr *LogicalRouter) {}
+func (s signal) OnLogicalRouterDelete(lr *LogicalRouter) {}
+
+func (s signal) OnLogicalRouterPortCreate(lrp *LogicalRouterPort) {}
+func (s signal) OnLogicalRouterPortDelete(lrp *LogicalRouterPort) {}
+
+func (s signal) OnLogicalRouterStaticRouteCreate(lrsr *LogicalRouterStaticRoute) {}
+func (s signal) OnLogicalRouterStaticRouteDelete(lrsr *LogicalRouterStaticRoute) {}
+
+func (s signal) OnACLCreate(acl *ACL) {}
+func (s signal) OnACLDelete(acl *ACL) {}
+
+func (s signal) OnDHCPOptionsCreate(dhcp *DHCPOptions) {}
+func (s signal) OnDHCPOptionsDelete(dhcp *DHCPOptions) {}
+
+func (s signal) OnQoSCreate(qos *QoS) {}
+func (s signal) OnQoSDelete(qos *QoS) {}
+
+func (s signal) OnLoadBalancerCreate(ls *LoadBalancer) {}
+func (s signal) OnLoadBalancerDelete(ls *LoadBalancer) {}
+
+func (s signal) OnMeterCreate(meter *Meter) {}
+func (s signal) OnMeterDelete(meter *Meter) {}
+
+func (s signal) OnMeterBandCreate(band *MeterBand) {}
+func (s signal) OnMeterBandDelete(band *MeterBand) {}
+
+// Create/delete chassis from south bound db
+func (s signal) OnChassisCreate(ch *Chassis) {}
+func (s signal) OnChassisDelete(ch *Chassis) {}
+
+// Create/delete encap from south bound db
+func (s signal) OnEncapCreate(ch *Encap) {}
+func (s signal) OnEncapDelete(ch *Encap) {}
+
 func buildOvnDbConfig(db string) *Config {
 	cfg := &Config{}
 	if db == DBNB || db == "" {
@@ -114,6 +157,9 @@ func buildOvnDbConfig(db string) *Config {
 			cfg.Addr = fmt.Sprintf("%s:%s:%d", strs[0], strs[1], port)
 		}
 	}
+
+	cfg.SignalCB = signal{}
+
 	return cfg
 }
 


### PR DESCRIPTION
If SignalCB is registered, the populateCache() function will always
call the rowToXXX() functions of each module. In rowToLogicalRouter()
it will crash at some point in most cases because the implementation
was trying to resolve the rows being referenced by the LR row, e.g.
the LB rows or LRP rows, which may not have been populated to the
cache yet.

In fact, the API was always treating the rows being referenced as
simply uuid strings rather than any specific fields, so there is
no point to resolve the rows. So this patch fixes it by following
the existed pattern, such as rowToLogicalSwitch, simply stores
the uuids of the rows being referenced.

Without this fix, the added signal handler in test_common.go would
cause test failures such as:

=== RUN   TestLRLoadBalancer
[unix nb1.ovsdb]
    logical_router_load_balancer_test.go:59: Adding LB to LRouter lr1
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6ab791]

goroutine 39 [running]:
github.com/ebay/go-ovn.(*ovndb).rowToLogicalRouter(0xc0002c4200, 0xc0001d0990, 0x24, 0x24)
	/home/hanzhou/go/src/github.com/ebay/go-ovn/logical_router.go:143 +0x13b1
github.com/ebay/go-ovn.(*ovndb).populateCache(0xc0002c4200, 0xc000158db0)
	/home/hanzhou/go/src/github.com/ebay/go-ovn/ovnimp.go:235 +0x19b4
github.com/ebay/go-ovn.ovnNotifier.Update(0xc0002c4200, 0x713e60, 0x9b06e0, 0xc000158db0)
	/home/hanzhou/go/src/github.com/ebay/go-ovn/ovnnotify.go:28 +0x35
github.com/ebay/libovsdb.update(0xc00030c770, 0xc00013f780, 0x2, 0x4, 0xc000499430, 0x0, 0x0)
	/home/hanzhou/go/pkg/mod/github.com/ebay/libovsdb@v0.0.0-20190718202342-e49b8c4e1142/client.go:216 +0x2e7
reflect.Value.call(0x7214c0, 0x78f4a8, 0x13, 0x773ebd, 0x4, 0xc00015ddd0, 0x3, 0x3, 0xc00015dd38, 0x4c161d, ...)
	/usr/local/go/src/reflect/value.go:475 +0x8c7
reflect.Value.Call(0x7214c0, 0x78f4a8, 0x13, 0xc00015ddd0, 0x3, 0x3, 0x1c8, 0xc00015ddc8, 0x634592)
	/usr/local/go/src/reflect/value.go:336 +0xb9
github.com/cenkalti/rpc2.(*Client).handleRequest(0xc00030c770, 0x0, 0xc00014b440, 0x6, 0xc00051a640, 0x70fac0, 0xc0002da3c0, 0x197)
	/home/hanzhou/go/pkg/mod/github.com/cenkalti/rpc2@v0.0.0-20170726070524-c51a77e5f664/client.go:131 +0x1cf
github.com/cenkalti/rpc2.(*Client).readRequest(0xc00030c770, 0xc0000b3e00, 0xc0000b3e20, 0x0)
	/home/hanzhou/go/pkg/mod/github.com/cenkalti/rpc2@v0.0.0-20170726070524-c51a77e5f664/client.go:179 +0x1cb
github.com/cenkalti/rpc2.(*Client).readLoop(0xc00030c770)
	/home/hanzhou/go/pkg/mod/github.com/cenkalti/rpc2@v0.0.0-20170726070524-c51a77e5f664/client.go:93 +0x14f
github.com/cenkalti/rpc2.(*Client).Run(0xc00030c770)
	/home/hanzhou/go/pkg/mod/github.com/cenkalti/rpc2@v0.0.0-20170726070524-c51a77e5f664/client.go:62 +0x2b
created by github.com/ebay/libovsdb.newRPC2Client
	/home/hanzhou/go/pkg/mod/github.com/ebay/libovsdb@v0.0.0-20190718202342-e49b8c4e1142/client.go:104 +0x376
exit status 2
FAIL	github.com/ebay/go-ovn	0.071s

Fixes: 82a71f5067fb1 ("show additional columns for LogicalRouter").
Signed-off-by: Han Zhou <hzhou8@ebay.com>