### PR TITLE
Port group API support

### DIFF
--- a/client.go
+++ b/client.go
@@ -206,6 +206,15 @@ type Client interface {
 	// Get SB_Global table options
 	SBGlobalGetOptions() (map[string]string, error)
 
+	// Creates a new port group in the Port_Group table named "group" with optional "ports" added to the group.
+	PortGroupAdd(group string, ports []string, external_ids map[string]string) (*OvnCommand, error)
+	// Sets "ports" and/or "external_ids" on the port group named "group". It is an error if group does not exist.
+	PortGroupUpdate(group string, ports []string, external_ids map[string]string) (*OvnCommand, error)
+	// Deletes port group "group". It is an error if "group" does not exist.
+	PortGroupDel(group string) (*OvnCommand, error)
+	// Get PortGroup data structure if it exists
+	PortGroupGet(group string) (*PortGroup, error)
+
 	// Close connection to OVN
 	Close() error
 }
@@ -667,6 +676,22 @@ func (c *ovndb) SBGlobalSetOptions(options map[string]string) (*OvnCommand, erro
 
 func (c *ovndb) SBGlobalGetOptions() (map[string]string, error) {
 	return c.sbGlobalGetOptionsImp()
+}
+
+func (c *ovndb) PortGroupAdd(group string, ports []string, external_ids map[string]string) (*OvnCommand, error) {
+	return c.pgAddImp(group, ports, external_ids)
+}
+
+func (c *ovndb) PortGroupUpdate(group string, ports []string, external_ids map[string]string) (*OvnCommand, error) {
+	return c.pgUpdateImp(group, ports, external_ids)
+}
+
+func (c *ovndb) PortGroupDel(group string) (*OvnCommand, error) {
+	return c.pgDelImp(group)
+}
+
+func (c *ovndb) PortGroupGet(group string) (*PortGroup, error) {
+	return c.pgGetImp(group)
 }
 
 // these functions are helpers for unit-tests, but not part of the API

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	commitTransactionText = "commiting transaction"
+	commitTransactionText = "committing transaction"
 )
 
 var (
@@ -38,6 +38,8 @@ var (
 	ErrorNotFound = errors.New("object not found")
 	// ErrorExist used when object already exists in ovnnb
 	ErrorExist = errors.New("object exist")
+	// ErrorNoChanges used when function called, but no changes
+	ErrorNoChanges = errors.New("no changes requested")
 )
 
 // OVNRow ovn nb/sb row

--- a/port_group.go
+++ b/port_group.go
@@ -43,11 +43,19 @@ func (odbi *ovndb) pgAddImp(group string, ports []string, external_ids map[strin
 	if uuid := odbi.getRowUUID(TablePortGroup, row); len(uuid) > 0 {
 		return nil, ErrorExist
 	}
-	pgports, err := libovsdb.NewOvsSet(ports)
-	if err != nil {
-		return nil, err
+
+	if ports != nil {
+		var portUUIDs []libovsdb.UUID
+		for _, u := range ports {
+			portUUIDs = append(portUUIDs, stringToGoUUID(u))
+		}
+		pgports, err := libovsdb.NewOvsSet(portUUIDs)
+		if err != nil {
+			return nil, err
+		}
+		row["ports"] = pgports
 	}
-	row["ports"] = pgports
+
 	if external_ids != nil {
 		oMap, err := libovsdb.NewOvsMap(external_ids)
 		if err != nil {
@@ -66,18 +74,30 @@ func (odbi *ovndb) pgAddImp(group string, ports []string, external_ids map[strin
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
-func (odbi *ovndb) pgSetPortsImp(group string, ports []string, external_ids map[string]string) (*OvnCommand, error) {
+func (odbi *ovndb) pgUpdateImp(group string, ports []string, external_ids map[string]string) (*OvnCommand, error) {
 	row := make(OVNRow)
 	row["name"] = group
 
 	if uuid := odbi.getRowUUID(TablePortGroup, row); len(uuid) == 0 {
 		return nil, ErrorNotFound
 	}
-	pgports, err := libovsdb.NewOvsSet(ports)
-	if err != nil {
-		return nil, err
+
+	if ports == nil && external_ids == nil {
+		return nil, ErrorNoChanges
 	}
-	row["ports"] = pgports
+
+	if ports != nil {
+		var portUUIDs []libovsdb.UUID
+		for _, u := range ports {
+			portUUIDs = append(portUUIDs, stringToGoUUID(u))
+		}
+		pgports, err := libovsdb.NewOvsSet(portUUIDs)
+		if err != nil {
+			return nil, err
+		}
+		row["ports"] = pgports
+	}
+
 	if external_ids != nil {
 		oMap, err := libovsdb.NewOvsMap(external_ids)
 		if err != nil {
@@ -95,7 +115,6 @@ func (odbi *ovndb) pgSetPortsImp(group string, ports []string, external_ids map[
 	}
 	operations := []libovsdb.Operation{updateOp}
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
-
 }
 
 func (odbi *ovndb) pgDelImp(group string) (*OvnCommand, error) {
@@ -107,6 +126,31 @@ func (odbi *ovndb) pgDelImp(group string) (*OvnCommand, error) {
 	}
 	operations := []libovsdb.Operation{deleteOp}
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
+func (odbi *ovndb) pgGetImp(pg string) (*PortGroup, error) {
+	var pgList []*PortGroup
+	odbi.cachemutex.RLock()
+	defer odbi.cachemutex.RUnlock()
+
+	cachePortGroup, ok := odbi.cache[TablePortGroup]
+	if !ok {
+		return nil, ErrorNotFound
+	}
+
+	for uuid, drows := range cachePortGroup {
+		if rlsw, ok := drows.Fields["name"].(string); ok && rlsw == pg {
+			pgList = append(pgList, odbi.RowToPortGroup(uuid))
+		}
+	}
+
+	if len(pgList) == 0 {
+		return nil, ErrorNotFound
+	} else if len(pgList) != 1 {
+		return nil, ErrorSchema
+	} else {
+		return pgList[0], nil
+	}
 }
 
 func (odbi *ovndb) RowToPortGroup(uuid string) *PortGroup {

--- a/port_group_test.go
+++ b/port_group_test.go
@@ -1,0 +1,381 @@
+/**
+ * Copyright (c) 2020 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless assertd by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package goovn
+
+import (
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+const (
+	PG_TEST_PG1         = "TestPortGroup1"
+	PG_TEST_PG2         = "TestPortGroup2"
+	PG_TEST_LS1         = "TestLogicalSwitch"
+	PG_TEST_LSP1        = "TestLogicalSwitchPort1"
+	PG_TEST_LSP2        = "TestLogicalSwitchPort2"
+	PG_TEST_LSP3        = "TestLogicalSwitchPort3"
+	PG_TEST_LSP4        = "TestLogicalSwitchPort4"
+	PG_TEST_KEY_1       = "mac_addr"
+	PG_TEST_ID_1        = "00:01:02:03:04:05"
+	PG_TEST_KEY_2       = "ip_addr"
+	PG_TEST_ID_2        = "169.254.1.1"
+	PG_TEST_KEY_3       = "foo1"
+	PG_TEST_ID_3        = "bar1"
+)
+
+type pgConfig struct {
+	pgName      string
+	ports       []string
+	externalIds map[string]string
+}
+
+type pgTest struct {
+name        string
+testFunc    func(group string, ports []string, external_ids map[string]string) (*OvnCommand, error)
+startConfig pgConfig
+testConfig  pgConfig
+}
+
+func lspNameToUUID(lspName string, c Client) (string, error) {
+	lsp1, err := c.LSPGet(lspName)
+	if err == nil {
+		return lsp1.UUID, nil
+	} else {
+		return "", ErrorNotFound
+	}
+}
+
+func compareExternalIds(want map[string]string, got map[interface{}]interface{}) bool {
+	if len(want) != len(got) {
+		return false
+	}
+	for key, w := range want {
+		if w != got[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPortGroupAPI(t *testing.T) {
+	ovndbapi := getOVNClient(DBNB)
+	assert := assert.New(t)
+	var cmd *OvnCommand
+	var err error
+
+	// create Switch with four ports
+	createSwitch := func(t *testing.T) {
+		t.Helper()
+		var cmds []*OvnCommand
+		// Create Switch
+		cmd, err := ovndbapi.LSAdd(PG_TEST_LS1)
+		assert.Nil(err)
+		cmds = append(cmds, cmd)
+		// Add ports
+		cmd, err = ovndbapi.LSPAdd(PG_TEST_LS1, PG_TEST_LSP1)
+		assert.Nil(err)
+		cmds = append(cmds, cmd)
+		cmd, err = ovndbapi.LSPAdd(PG_TEST_LS1, PG_TEST_LSP2)
+		assert.Nil(err)
+		cmds = append(cmds, cmd)
+		cmd, err = ovndbapi.LSPAdd(PG_TEST_LS1, PG_TEST_LSP3)
+		assert.Nil(err)
+		cmds = append(cmds, cmd)
+		cmd, err = ovndbapi.LSPAdd(PG_TEST_LS1, PG_TEST_LSP4)
+		assert.Nil(err)
+		cmds = append(cmds, cmd)
+
+		err = ovndbapi.Execute(cmds...)
+		assert.Nil(err)
+	}
+
+	// Delete Switch
+	deleteSwitch := func(t *testing.T) {
+		t.Helper()
+
+		cmd, err = ovndbapi.LSDel(PG_TEST_LS1)
+		assert.Nil(err)
+
+		err = ovndbapi.Execute(cmd)
+		assert.Nil(err)
+	}
+
+	// Create a switch w/four ports to be used for logical port tests
+	createSwitch(t)
+
+	// LSP commands require that ports be described by a UUID, so get the UUIDs
+	lsp1UUID, err := lspNameToUUID(PG_TEST_LSP1, ovndbapi)
+	assert.Nil(err)
+	lsp2UUID, err := lspNameToUUID(PG_TEST_LSP2, ovndbapi)
+	assert.Nil(err)
+	lsp3UUID, err := lspNameToUUID(PG_TEST_LSP3, ovndbapi)
+	assert.Nil(err)
+	lsp4UUID, err := lspNameToUUID(PG_TEST_LSP4, ovndbapi)
+	assert.Nil(err)
+
+	portGroupAddTests := []pgTest {
+		{
+			name: "add an empty port group",
+			testFunc: ovndbapi.PortGroupAdd,
+			startConfig: pgConfig{
+				pgName:"",
+				ports: nil,
+				externalIds: nil,
+			},
+			testConfig: pgConfig{
+				pgName: PG_TEST_PG1,
+				ports: nil,
+				externalIds: nil,
+			},
+		},
+		{
+			name: "add a port group with two ports",
+			testFunc: ovndbapi.PortGroupAdd,
+			startConfig: pgConfig{
+				pgName:"",
+				ports:nil,
+				externalIds:nil,
+			},
+			testConfig: pgConfig{
+				pgName: PG_TEST_PG1,
+				ports: []string{lsp1UUID, lsp2UUID},
+				externalIds: nil,
+			},
+		},
+		{
+			name: "add a port group with four ports",
+			testFunc: ovndbapi.PortGroupAdd,
+			startConfig: pgConfig{
+				pgName:"",
+				ports:nil,
+				externalIds:nil,
+			},
+			testConfig: pgConfig{
+				pgName: PG_TEST_PG1,
+				ports: []string{lsp1UUID, lsp2UUID, lsp3UUID, lsp4UUID},
+				externalIds: nil,
+			},
+		},
+		{
+			name: "add two port groups with the same ports",
+			testFunc: ovndbapi.PortGroupAdd,
+			startConfig: pgConfig{
+				pgName: PG_TEST_PG1,
+				ports: []string{lsp1UUID, lsp2UUID},
+				externalIds: nil,
+			},
+			testConfig: pgConfig{
+				pgName: PG_TEST_PG2,
+				ports: []string{lsp1UUID, lsp2UUID},
+				externalIds: nil,
+			},
+		},
+		{
+			name: "add a port group with external ids",
+			testFunc: ovndbapi.PortGroupAdd,
+			startConfig: pgConfig{
+				pgName:"",
+				ports:nil,
+				externalIds:nil,
+			},
+			testConfig: pgConfig{
+				pgName: PG_TEST_PG1,
+				ports: nil,
+				externalIds: map[string]string{PG_TEST_KEY_1: PG_TEST_ID_1, PG_TEST_KEY_2: PG_TEST_ID_2},
+			},
+		},
+		{
+			name: "add a port group with ports and external ids",
+			testFunc: ovndbapi.PortGroupAdd,
+			startConfig: pgConfig{
+				pgName:"",
+				ports:nil,
+				externalIds:nil,
+			},
+			testConfig: pgConfig{
+				pgName: PG_TEST_PG1,
+				ports: []string{lsp1UUID, lsp2UUID},
+				externalIds: map[string]string{PG_TEST_KEY_1: PG_TEST_ID_1, PG_TEST_KEY_2: PG_TEST_ID_2},
+			},
+		},
+		{
+			name: "add a port group with empty name",
+			testFunc: ovndbapi.PortGroupAdd,
+			startConfig: pgConfig{
+				pgName:"",
+				ports:nil,
+				externalIds:nil,
+			},
+			testConfig: pgConfig{
+				pgName: "",
+				ports:nil,
+				externalIds:nil,
+			},
+		},
+		{
+			name: "add a port group when another exists",
+			testFunc: ovndbapi.PortGroupAdd,
+			startConfig: pgConfig{
+				pgName: PG_TEST_PG1,
+				ports: []string{lsp1UUID, lsp2UUID},
+				externalIds: map[string]string{PG_TEST_KEY_1: PG_TEST_ID_1, PG_TEST_KEY_2: PG_TEST_ID_2},
+			},
+			testConfig: pgConfig{
+				pgName: PG_TEST_PG2,
+				ports: []string{lsp3UUID, lsp4UUID},
+				externalIds: map[string]string{PG_TEST_KEY_1: PG_TEST_ID_1, PG_TEST_KEY_2: PG_TEST_ID_2},
+			},
+		},
+		{
+			name: "set ports and external ids on existing empty port group",
+			testFunc: ovndbapi.PortGroupUpdate,
+			startConfig: pgConfig{
+				pgName:PG_TEST_PG1,
+				ports:nil,
+				externalIds:nil,
+			},
+			testConfig: pgConfig{
+				pgName: PG_TEST_PG1,
+				ports: []string{lsp1UUID, lsp2UUID},
+				externalIds: map[string]string{PG_TEST_KEY_1: PG_TEST_ID_1, PG_TEST_KEY_2: PG_TEST_ID_2},
+			},
+		},
+		{
+			name: "set ports and external ids on existing port group with exiting config",
+			testFunc: ovndbapi.PortGroupUpdate,
+			startConfig: pgConfig{
+				pgName:PG_TEST_PG1,
+				ports: []string{lsp1UUID, lsp2UUID},
+				externalIds: map[string]string{PG_TEST_KEY_1: PG_TEST_ID_1},
+			},
+			testConfig: pgConfig{
+				pgName:PG_TEST_PG1,
+				ports: []string{lsp3UUID, lsp4UUID},
+				externalIds: map[string]string{PG_TEST_KEY_2: PG_TEST_ID_2, PG_TEST_KEY_3: PG_TEST_ID_3},
+			},
+		},
+	}
+
+	for _, tc := range portGroupAddTests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.startConfig.pgName != "" {
+				// Add start config
+				cmd, err = ovndbapi.PortGroupAdd(tc.startConfig.pgName, tc.startConfig.ports, tc.startConfig.externalIds)
+				assert.Nil(err)
+				err = ovndbapi.Execute(cmd)
+				assert.Nil(err)
+			}
+
+			// Add or Set the port group
+			cmd, err = tc.testFunc(tc.testConfig.pgName, tc.testConfig.ports, tc.testConfig.externalIds)
+			assert.Nil(err)
+			err = ovndbapi.Execute(cmd)
+			assert.Nil(err)
+
+			// Validate port group
+			pg, err := ovndbapi.PortGroupGet(tc.testConfig.pgName)
+			assert.Nil(err)
+			assert.NotNil(pg)
+			assert.Equal(pg.Name, tc.testConfig.pgName)
+			if tc.testConfig.ports != nil {
+				sort.Strings(tc.testConfig.ports)
+				sort.Strings(pg.Ports)
+				assert.True(reflect.DeepEqual(tc.testConfig.ports, pg.Ports))
+			}
+			if tc.testConfig.externalIds != nil {
+				assert.True(compareExternalIds(tc.testConfig.externalIds, pg.ExternalID))
+			}
+
+			// Delete the port group
+			cmd, err = ovndbapi.PortGroupDel(tc.testConfig.pgName)
+			assert.Nil(err)
+			err = ovndbapi.Execute(cmd)
+			assert.Nil(err)
+
+			// Confirm that it's deleted
+			_, err = ovndbapi.PortGroupGet(tc.testConfig.pgName)
+			assert.NotNil(err)
+
+			if (tc.startConfig.pgName != "") &&  (tc.startConfig.pgName != tc.testConfig.pgName) {
+				// Delete the start config port group.
+				cmd, err = ovndbapi.PortGroupDel(tc.startConfig.pgName)
+				assert.Nil(err)
+				err = ovndbapi.Execute(cmd)
+				assert.Nil(err)
+			}
+		})
+	}
+
+	// The following are negative/boundary cases that are not as easy to generalize
+
+	t.Run("add duplicate port group", func(t *testing.T) {
+		// Add first port group
+		cmd, err = ovndbapi.PortGroupAdd(PG_TEST_PG1, []string{lsp1UUID, lsp2UUID}, nil)
+		assert.Nil(err)
+		err = ovndbapi.Execute(cmd)
+		assert.Nil(err)
+
+		cmd, err = ovndbapi.PortGroupAdd(PG_TEST_PG1, []string{lsp1UUID, lsp2UUID}, nil)
+		assert.NotNil(err)
+
+		// Delete the first port group
+		cmd, err = ovndbapi.PortGroupDel(PG_TEST_PG1)
+		assert.Nil(err)
+		err = ovndbapi.Execute(cmd)
+		assert.Nil(err)
+	})
+
+	t.Run("add port group with non-existent ports", func(t *testing.T) {
+		badUUID, err := uuid.NewRandom()
+		assert.Nil(err)
+		ports := []string{lsp1UUID, badUUID.String()}
+
+		// Add the port group
+		cmd, err = ovndbapi.PortGroupAdd(PG_TEST_PG1, ports, nil)
+		assert.Nil(err)
+		err = ovndbapi.Execute(cmd)
+		assert.Nil(err)
+		// The way this currently works, ovsdb doesn't care whether the ports exist,
+		// and will add the port group regardless. Should it?
+
+		// Validate port group
+		pg, err := ovndbapi.PortGroupGet(PG_TEST_PG1)
+		assert.Nil(err)
+		assert.NotNil(pg)
+		assert.Equal(pg.Name, PG_TEST_PG1)
+		sort.Strings(ports)
+		sort.Strings(pg.Ports)
+		// Don't expect the badUUID to be in the list
+		assert.False(reflect.DeepEqual(ports, pg.Ports))
+
+		// Delete the port group
+		cmd, err = ovndbapi.PortGroupDel(PG_TEST_PG1)
+		assert.Nil(err)
+		err = ovndbapi.Execute(cmd)
+		assert.Nil(err)
+	})
+
+	t.Run("set port group that doesn't exist", func(t *testing.T) {
+		cmd, err = ovndbapi.PortGroupUpdate(PG_TEST_PG1, []string{lsp1UUID, lsp2UUID}, nil)
+		assert.NotNil(err)
+	})
+
+	deleteSwitch(t)
+}


### PR DESCRIPTION
ovn-kubernetes needs the ability to add ACLs to port groups, but the current ACL APIs only support logical switches, and there are no port group APIs. This PR adds port group API support and tests.