### PR TITLE
use build tag to group tests that needs to be mandatorily run as part of travis test script

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -112,7 +112,7 @@ ovn_start_db sb standalone 1 $srcdir/../ovn/ovn-sb.ovsschema
 export GO111MODULE=on
 cd ../
 go get -v ./...
-go test -v
+go test -v -tags=travis
 
 ovs-appctl -t ${OVS_RUNDIR}/nb1 exit
 ovs-appctl -t ${OVS_RUNDIR}/sb1 exit

--- a/nb_global_test.go
+++ b/nb_global_test.go
@@ -1,3 +1,5 @@
+// +build travis
+
 /**
  * Copyright (c) 2020 eBay Inc.
  *

--- a/sb_global_test.go
+++ b/sb_global_test.go
@@ -1,3 +1,5 @@
+// +build travis
+
 /**
  * Copyright (c) 2020 eBay Inc.
  *


### PR DESCRIPTION
This PR adds a build tag `travis` for the files `sb_global_test.go` and `nb_global_test.go`. The tests `TestSBGlobalAPI` and `TestNBGlobalAPI`run successfully only when the `.travis\test.sh` script is invoked which is long running and is needed as part of travis CI run.
For all other tests, the regular go testing command 'go test' should be sufficent and faster. So now with this PR, one can execute `OVN_NB_DB=unix:ovnnb_db.sock OVN_SB_DB=unix:ovnsb_db.sock OVS_RUNDIR=/var/run/ovn go test` which will skip the TestSBGlobalAPI` and `TestNBGlobalAPI` tests but run everything else. The TestSBGlobalAPI` and `TestNBGlobalAPI` tests will still continue to be run along with the other tests when the `.travis/test.sh` is executed

Signed-off-by: Vishwanath Jayaraman <vjayaram@redhat.com>