### PR TITLE
onvimp: enforce table ordering in cache population

### DIFF
--- a/common.go
+++ b/common.go
@@ -54,6 +54,10 @@ const (
 	TableSBGlobal                 string = "SB_Global"
 )
 
+/* Ordered NorthBound Tables
+The cache will be populated following this order.
+Care must be taken too keep reference targets before their sources.
+*/
 var NBTablesOrder = []string{
 	TableNBGlobal,
 	TableAddressSet,
@@ -76,6 +80,10 @@ var NBTablesOrder = []string{
 	TableLogicalRouter,
 }
 
+/* Ordered SouthBound Tables
+The cache will be populated following this order.
+Care must be taken too keep reference targets before their sources.
+*/
 var SBTablesOrder = []string{
 	TableChassis,
 	TableEncap,

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -210,7 +210,17 @@ func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 	odbi.cachemutex.Lock()
 	defer odbi.cachemutex.Unlock()
 
-	for table := range odbi.tableCols {
+	var tableOrder []string
+	if odbi.db == DBNB {
+		tableOrder = NBTablesOrder
+	} else {
+		tableOrder = SBTablesOrder
+	}
+
+	for _, table := range tableOrder {
+		if _, ok := odbi.tableCols[table]; !ok {
+			continue
+		}
 		tableUpdate, ok := updates.Updates[table]
 		if !ok {
 			continue


### PR DESCRIPTION
When the cache is populated, a specific order must be preserved that
ensures that if table A refereces table B, B is populated before A.

This assumption seems widely made in the RowTo{XXX} functions. So,
this patch enforces this ordering.

Fixes: #119 
Signed-off-by: Adrian Moreno <amorenoz@redhat.com>