### PR TITLE
Added support for ACLs on port groups.

### DIFF
--- a/acl.go
+++ b/acl.go
@@ -33,17 +33,28 @@ type ACL struct {
 	ExternalID map[interface{}]interface{}
 }
 
-func (odbi *ovndb) getACLUUIDByRow(lsw, table string, row OVNRow) (string, error) {
+func (odbi *ovndb) getACLUUIDByRow(entityType EntityType, entity string, row OVNRow) (string, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalSwitch, ok := odbi.cache[TableLogicalSwitch]
+	var tableName string
+
+	switch entityType {
+	case LOGICAL_SWITCH:
+		tableName = TableLogicalSwitch
+	case PORT_GROUP:
+		tableName = TablePortGroup
+	default:
+		return "", ErrorOption
+	}
+
+	tableCache, ok := odbi.cache[tableName]
 	if !ok {
 		return "", ErrorSchema
 	}
 
-	for _, drows := range cacheLogicalSwitch {
-		if rlsw, ok := drows.Fields["name"].(string); ok && rlsw == lsw {
+	for _, drows := range tableCache {
+		if rlsw, ok := drows.Fields["name"].(string); ok && rlsw == entity {
 			acls := drows.Fields["acls"]
 			if acls != nil {
 				switch acls.(type) {
@@ -134,7 +145,18 @@ func (odbi *ovndb) getACLUUIDByRow(lsw, table string, row OVNRow) (string, error
 	return "", ErrorNotFound
 }
 
-func (odbi *ovndb) aclAddImp(lsw, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter string, severity string) (*OvnCommand, error) {
+func (odbi *ovndb) aclAddImp(entityType EntityType, entity, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter, severity string) (*OvnCommand, error) {
+	var table string
+
+	switch entityType {
+	case LOGICAL_SWITCH:
+		table = TableLogicalSwitch
+	case PORT_GROUP:
+		table = TablePortGroup
+	default:
+		return nil, ErrorOption
+	}
+
 	namedUUID, err := newRowUUID()
 	if err != nil {
 		return nil, err
@@ -144,7 +166,7 @@ func (odbi *ovndb) aclAddImp(lsw, direct, match, action string, priority int, ex
 	row["match"] = match
 	row["priority"] = priority
 
-	_, err = odbi.getACLUUIDByRow(lsw, TableACL, row)
+	_, err = odbi.getACLUUIDByRow(entityType, entity, row)
 	switch err {
 	case ErrorNotFound:
 		break
@@ -191,12 +213,12 @@ func (odbi *ovndb) aclAddImp(lsw, direct, match, action string, priority int, ex
 		return nil, err
 	}
 	mutation := libovsdb.NewMutation("acls", opInsert, mutateSet)
-	condition := libovsdb.NewCondition("name", "==", lsw)
+	condition := libovsdb.NewCondition("name", "==", entity)
 
 	// simple mutate operation
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     TableLogicalSwitch,
+		Table:     table,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -204,7 +226,18 @@ func (odbi *ovndb) aclAddImp(lsw, direct, match, action string, priority int, ex
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
-func (odbi *ovndb) aclDelImp(lsw, direct, match string, priority int, external_ids map[string]string) (*OvnCommand, error) {
+func (odbi *ovndb) aclDelImp(entityType EntityType, entity, direct, match string, priority int, external_ids map[string]string) (*OvnCommand, error) {
+	var table string
+
+	switch entityType {
+	case LOGICAL_SWITCH:
+		table = TableLogicalSwitch
+	case PORT_GROUP:
+		table = TablePortGroup
+	default:
+		return nil, ErrorOption
+	}
+
 	row := make(OVNRow)
 
 	wherecondition := []interface{}{}
@@ -214,7 +247,7 @@ func (odbi *ovndb) aclDelImp(lsw, direct, match string, priority int, external_i
 	if match != "" {
 		row["match"] = match
 	}
-	//in ovn pirority is greater than/equal 0,
+	//in ovn priority is greater than/equal 0,
 	//if input the priority < 0, lots of acls will be deleted if matches direct and match condition judgement.
 	if priority >= 0 {
 		row["priority"] = priority
@@ -228,7 +261,7 @@ func (odbi *ovndb) aclDelImp(lsw, direct, match string, priority int, external_i
 		row["external_ids"] = oMap
 	}
 
-	aclUUID, err := odbi.getACLUUIDByRow(lsw, TableACL, row)
+	aclUUID, err := odbi.getACLUUIDByRow(entityType, entity, row)
 	if err != nil {
 		return nil, err
 	}
@@ -242,12 +275,12 @@ func (odbi *ovndb) aclDelImp(lsw, direct, match string, priority int, external_i
 	}
 
 	mutation := libovsdb.NewMutation("acls", opDelete, stringToGoUUID(aclUUID))
-	condition := libovsdb.NewCondition("name", "==", lsw)
+	condition := libovsdb.NewCondition("name", "==", entity)
 
 	// Simple mutate operation
 	mutateOp := libovsdb.Operation{
 		Op:        opMutate,
-		Table:     TableLogicalSwitch,
+		Table:     table,
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{condition},
 	}
@@ -299,16 +332,28 @@ func (odbi *ovndb) rowToACL(uuid string) *ACL {
 }
 
 // Get all acl by lswitch
-func (odbi *ovndb) aclListImp(lsw string) ([]*ACL, error) {
+func (odbi *ovndb) aclListImp(entityType EntityType, entity string) ([]*ACL, error) {
 	odbi.cachemutex.RLock()
 	defer odbi.cachemutex.RUnlock()
 
-	cacheLogicalSwitch, ok := odbi.cache[TableLogicalSwitch]
-	if !ok {
-		return nil, ErrorNotFound
+	var tableName string
+
+	switch entityType {
+	case LOGICAL_SWITCH:
+		tableName = TableLogicalSwitch
+	case PORT_GROUP:
+		tableName = TablePortGroup
+	default:
+		return nil, ErrorOption
 	}
-	for _, drows := range cacheLogicalSwitch {
-		if rlsw, ok := drows.Fields["name"].(string); ok && rlsw == lsw {
+
+	tableCache, ok := odbi.cache[tableName]
+	if !ok {
+		return nil, ErrorSchema
+	}
+
+	for _, drows := range tableCache {
+		if rowName, ok := drows.Fields["name"].(string); ok && rowName == entity {
 			acls := drows.Fields["acls"]
 			if acls != nil {
 				switch acls.(type) {

--- a/port_group.go
+++ b/port_group.go
@@ -45,7 +45,7 @@ func (odbi *ovndb) pgAddImp(group string, ports []string, external_ids map[strin
 	}
 
 	if ports != nil {
-		var portUUIDs []libovsdb.UUID
+		portUUIDs := make([]libovsdb.UUID, 0, len(ports))
 		for _, u := range ports {
 			portUUIDs = append(portUUIDs, stringToGoUUID(u))
 		}
@@ -87,7 +87,7 @@ func (odbi *ovndb) pgUpdateImp(group string, ports []string, external_ids map[st
 	}
 
 	if ports != nil {
-		var portUUIDs []libovsdb.UUID
+		portUUIDs := make([]libovsdb.UUID, 0, len(ports))
 		for _, u := range ports {
 			portUUIDs = append(portUUIDs, stringToGoUUID(u))
 		}

--- a/port_group_test.go
+++ b/port_group_test.go
@@ -24,22 +24,6 @@ import (
 	"testing"
 )
 
-const (
-	PG_TEST_PG1         = "TestPortGroup1"
-	PG_TEST_PG2         = "TestPortGroup2"
-	PG_TEST_LS1         = "TestLogicalSwitch"
-	PG_TEST_LSP1        = "TestLogicalSwitchPort1"
-	PG_TEST_LSP2        = "TestLogicalSwitchPort2"
-	PG_TEST_LSP3        = "TestLogicalSwitchPort3"
-	PG_TEST_LSP4        = "TestLogicalSwitchPort4"
-	PG_TEST_KEY_1       = "mac_addr"
-	PG_TEST_ID_1        = "00:01:02:03:04:05"
-	PG_TEST_KEY_2       = "ip_addr"
-	PG_TEST_ID_2        = "169.254.1.1"
-	PG_TEST_KEY_3       = "foo1"
-	PG_TEST_ID_3        = "bar1"
-)
-
 type pgConfig struct {
 	pgName      string
 	ports       []string

--- a/test_common.go
+++ b/test_common.go
@@ -36,8 +36,10 @@ const (
 	LSP                  = "TEST_LSP"
 	LSP_SECOND           = "TEST_LSP_SECOND "
 	ADDR                 = "36:46:56:76:86:96 127.0.0.1"
+	ADDR2                = "36:46:56:76:86:97 192.168.1.10"
 	MATCH                = "outport == \"96d44061-1823-428b-a7ce-f473d10eb3d0\" && ip && ip.dst == 10.97.183.61"
 	MATCH_SECOND         = "outport == \"96d44061-1823-428b-a7ce-f473d10eb3d0\" && ip && ip.dst == 10.97.183.62"
+	MATCH3               = "ip && ip.dst == 10.97.183.64"
 	defaultClientCACert  = "/etc/openvswitch/client_ca_cert.pem"
 	defaultClientPrivKey = "/etc/openvswitch/ovnnb-privkey.pem"
 	SKIP_TLS_VERIFY      = true
@@ -46,6 +48,19 @@ const (
 	FAKENOCHASSIS        = "fakenochassis"
 	FAKENOSWITCH         = "fakenoswitch"
 	FAKENOROUTER         = "fakenorouter"
+	PG_TEST_PG1          = "TestPortGroup1"
+	PG_TEST_PG2          = "TestPortGroup2"
+	PG_TEST_LS1          = "TestLogicalSwitch"
+	PG_TEST_LSP1         = "TestLogicalSwitchPort1"
+	PG_TEST_LSP2         = "TestLogicalSwitchPort2"
+	PG_TEST_LSP3         = "TestLogicalSwitchPort3"
+	PG_TEST_LSP4         = "TestLogicalSwitchPort4"
+	PG_TEST_KEY_1        = "mac_addr"
+	PG_TEST_ID_1         = "00:01:02:03:04:05"
+	PG_TEST_KEY_2        = "ip_addr"
+	PG_TEST_ID_2         = "169.254.1.1"
+	PG_TEST_KEY_3        = "foo1"
+	PG_TEST_ID_3         = "bar1"
 )
 
 var (


### PR DESCRIPTION
 Added support for ACLs on port groups.
 - Using ovn-nbctl acl-add/del as a model, an entityType parameter was added to
the API which could be either PORT_GROUP or LOICAL_SWITCH.
- In order to maintain backward compatibility of the existing APIs, a new set
of APIs called ACLAddEntity/ACLDelEntity/ACLListEntity were added.
- Note: both versions of the APIs call the same underlying
implementation functions.
    
Also made a minor optimization suggested by vtolstov on pr-117.
    
Signed-off-by: Andre Fredette <afredette@redhat.com>