### PR TITLE
better developer experience: ability to run tests inside docker containers

### DIFF
--- a/utilities/docker/Dockerfile
+++ b/utilities/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM openvswitch/ovn:2.12_e60f2f2_debian_master
+
+ARG GOVERPKG=go1.13.9.linux-amd64.tar.gz
+RUN apt-get update
+RUN apt-get install -y wget git gcc python3-pip python3-dev build-essential autoconf automake libtool
+
+RUN wget -P /tmp https://dl.google.com/go/$GOVERPKG
+
+RUN tar -C /usr/local -xzf /tmp/$GOVERPKG
+RUN rm /tmp/$GOVERPKG
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+
+WORKDIR $GOPATH
+
+RUN apt-get install -y supervisor
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+ENTRYPOINT ["/usr/bin/supervisord"]

--- a/utilities/docker/README.md
+++ b/utilities/docker/README.md
@@ -1,0 +1,21 @@
+- Goal: Add ability to run the go-ovn tests inside of a docker container which in turn would make it easy to run on 
+  non-linux systems that have docker installed. The docker image installs `go` binaries and sets the `GOPATH` environment
+  variable.
+
+- To build the docker image execute the below on a system where docker is installed
+
+  ```docker build -t <image_name>:<tag_name> .```
+
+- To execute the tests, 
+  a)first, mount the path to the go-ovn repo when running the container as below:
+  
+  ```
+  docker run -itd -v <PATH_TO_GO_OVN_REPO>:/go/src/github.com/eBay/go-ovn <image_name>:<tag_name>
+  ```
+  
+  b)next, exec into shell of the running container ( `docker exec -it <running_container_name> bash`) and execute the
+  below command to run the tests
+  
+  ```
+  OVS_RUNDIR=/var/run/ovn OVN_NB_DB=unix:ovnnb_db.sock OVN_SB_DB=unix:ovnsb_db.sock go test -v ./...
+  ```

--- a/utilities/docker/supervisord.conf
+++ b/utilities/docker/supervisord.conf
@@ -1,0 +1,11 @@
+[supervisord]
+nodaemon=true
+
+[program:ovn-nb-tcp]
+command=/bin/start-ovn ovn-nb-tcp
+
+[program:ovn-sb-tcp]
+command=/bin/start-ovn ovn-sb-tcp
+
+[program:ovn-northd-tcp]
+command=/bin/start-ovn ovn-northd-tcp


### PR DESCRIPTION
The goal of this PR is to allow for developers (running on non linux systems such as MacBook and who do not have ovs/ovn installed) to be be able to run the tests in containers instead. 
The PR creates a Dockerfile based off the `openvswitch/ovn:2.12_e60f2f2_debian_master` base image and adds go binaries. It also installs `supervisord` to help with running ovn-nb, ovn-sb and ovn-northd in the same container. (Refer http://supervisord.org/introduction.html)

Note: I have an enhancement request in the ovn-org/ovn repo requesting that official docker images for each of the OVN release to quay/docker repo (refer https://github.com/ovn-org/ovn/issues/67)