### PR TITLE
Implement a new API called ExecuteR()

### DIFF
--- a/acl_test.go
+++ b/acl_test.go
@@ -200,7 +200,6 @@ func TestLogicalSwitchACLs(t *testing.T) {
 	}
 	assert.Equal(t, true, len(acls) == 4, "test[%s]", "add second acl")
 
-
 	cmd, err = ovndbapi.ACLDel(LSW, "to-lport", MATCH_SECOND, 1002, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -349,10 +348,10 @@ func compareMeterSlices(s1, s2 []string) bool {
 func containsACL(aclList []*ACL, acl *ACL) bool{
 	for _, a := range aclList {
 		// Compare everything except UUID
-		if a.Action == acl.Action && 
-			a.Direction == acl.Direction && 
-			a.Match == acl.Match && 
-			a.Priority == acl.Priority && 
+		if a.Action == acl.Action &&
+			a.Direction == acl.Direction &&
+			a.Match == acl.Match &&
+			a.Priority == acl.Priority &&
 			a.Log == acl.Log &&
 			compareMeterSlices(a.Meter, acl.Meter) &&
 			a.Severity == acl.Severity &&
@@ -408,14 +407,12 @@ func TestPortGroupACLs(t *testing.T) {
 		cmds = append(cmds, cmd)
 		assert.Nil(t, err)
 
-		err = ovndbapi.Execute(cmds...)
+		result, err := ovndbapi.ExecuteR(cmds...)
 		assert.Nil(t, err)
+		assert.Equal(t, 3, len(result))
 
-		// LSP commands require that ports be described by a UUID, so get the UUIDs
-		lsp1UUID, err := lspNameToUUID(PG_TEST_LSP1, ovndbapi)
-		assert.Nil(t, err)
-		lsp2UUID, err := lspNameToUUID(PG_TEST_LSP2, ovndbapi)
-		assert.Nil(t, err)
+		lsp1UUID := result[1]
+		lsp2UUID := result[2]
 
 		// Create port group
 		cmd, err = ovndbapi.PortGroupAdd(PG_TEST_PG1, []string{lsp1UUID, lsp2UUID}, nil)

--- a/client.go
+++ b/client.go
@@ -193,6 +193,8 @@ type Client interface {
 	MeterBandsList() ([]*MeterBand, error)
 	// Exec command, support mul-commands in one transaction.
 	Execute(cmds ...*OvnCommand) error
+	// Same as Execute, but returns a UUID for each object created.
+	ExecuteR(cmds ...*OvnCommand) ([]string, error)
 
 	// Add chassis with given name
 	ChassisAdd(name string, hostname string, etype []string, ip string, external_ids map[string]string,
@@ -654,6 +656,10 @@ func (c *ovndb) QoSList(ls string) ([]*QoS, error) {
 
 func (c *ovndb) Execute(cmds ...*OvnCommand) error {
 	return c.execute(cmds...)
+}
+
+func (c *ovndb) ExecuteR(cmds ...*OvnCommand) ([]string, error) {
+	return c.executeR(cmds...)
 }
 
 func (c *ovndb) LSGet(ls string) ([]*LogicalSwitch, error) {

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -194,22 +194,23 @@ func (odbi *ovndb) executeR(cmds ...*OvnCommand) ([]string, error) {
 	}
 
 	results, err := odbi.transact(odbi.db, ops...)
-	if err == nil {
-		// The total number of UUIDs will be <= number of results returned.
-		UUIDs := make([]string, 0, len(results))
-		for _, r := range results {
-			if len(r.UUID.GoUUID) >0 {
-				UUIDs = append(UUIDs, r.UUID.GoUUID)
-			}
-		}
-		if len(UUIDs) > 0 {
-			return UUIDs, nil
-		} else {
-			return nil, nil
-		}
-	} else {
+	if err != nil {
 		return nil, err
 	}
+
+	// The total number of UUIDs will be <= number of results returned.
+	UUIDs := make([]string, 0, len(results))
+	for _, r := range results {
+		if len(r.UUID.GoUUID) > 0 {
+			UUIDs = append(UUIDs, r.UUID.GoUUID)
+		}
+	}
+
+	if len(UUIDs) > 0 {
+		return UUIDs, nil
+	}
+
+	return nil, nil
 }
 
 func (odbi *ovndb) float64_to_int(row libovsdb.Row) {

--- a/port_group_test.go
+++ b/port_group_test.go
@@ -37,15 +37,6 @@ startConfig pgConfig
 testConfig  pgConfig
 }
 
-func lspNameToUUID(lspName string, c Client) (string, error) {
-	lsp1, err := c.LSPGet(lspName)
-	if err == nil {
-		return lsp1.UUID, nil
-	} else {
-		return "", ErrorNotFound
-	}
-}
-
 func compareExternalIds(want map[string]string, got map[interface{}]interface{}) bool {
 	if len(want) != len(got) {
 		return false
@@ -63,6 +54,7 @@ func TestPortGroupAPI(t *testing.T) {
 	assert := assert.New(t)
 	var cmd *OvnCommand
 	var err error
+	var lsp1UUID, lsp2UUID, lsp3UUID, lsp4UUID string
 
 	// create Switch with four ports
 	createSwitch := func(t *testing.T) {
@@ -86,8 +78,14 @@ func TestPortGroupAPI(t *testing.T) {
 		assert.Nil(err)
 		cmds = append(cmds, cmd)
 
-		err = ovndbapi.Execute(cmds...)
+		result, err := ovndbapi.ExecuteR(cmds...)
 		assert.Nil(err)
+
+		assert.Equal(5, len(result))
+		lsp1UUID = result[1]
+		lsp2UUID = result[2]
+		lsp3UUID = result[3]
+		lsp4UUID = result[4]
 	}
 
 	// Delete Switch
@@ -103,16 +101,6 @@ func TestPortGroupAPI(t *testing.T) {
 
 	// Create a switch w/four ports to be used for logical port tests
 	createSwitch(t)
-
-	// LSP commands require that ports be described by a UUID, so get the UUIDs
-	lsp1UUID, err := lspNameToUUID(PG_TEST_LSP1, ovndbapi)
-	assert.Nil(err)
-	lsp2UUID, err := lspNameToUUID(PG_TEST_LSP2, ovndbapi)
-	assert.Nil(err)
-	lsp3UUID, err := lspNameToUUID(PG_TEST_LSP3, ovndbapi)
-	assert.Nil(err)
-	lsp4UUID, err := lspNameToUUID(PG_TEST_LSP4, ovndbapi)
-	assert.Nil(err)
 
 	portGroupAddTests := []pgTest {
 		{


### PR DESCRIPTION
ExecuteR() works the same as the existing Execute() function, except that it returns a list of UUIDs -- one for each object created in the call. If no objects are created in the ExecuteR call, or there is an error, nil is returned. Execute() has been updated to call ExecuteR() and ignore the returned UUIDs to avoid duplication of code.

The reason such a command is useful is that in many cases, the user of our API needs the UUID of the object or objects created. In order to get that UUID, an additional call and in some cases code is needed to get the object and then extract the UUID. Since we already have the UUID in the libovsdb.OperationResult returned from transact, it's more efficient to return it from the Execute call.