### PR TITLE
add universal handlers for LS external_ids and other_config records 

### DIFF
--- a/client.go
+++ b/client.go
@@ -64,6 +64,8 @@ type Client interface {
 	LSPDel(lsp string) (*OvnCommand, error)
 	// Set addressset per lport
 	LSPSetAddress(lsp string, addresses ...string) (*OvnCommand, error)
+	// Set lport type
+	LSPSetType(lsp string, portType string) (*OvnCommand, error)
 	// Set port security per lport
 	LSPSetPortSecurity(lsp string, security ...string) (*OvnCommand, error)
 	// Get all lport by lswitch
@@ -453,6 +455,10 @@ func (c *ovndb) LSPDel(lsp string) (*OvnCommand, error) {
 
 func (c *ovndb) LSPSetAddress(lsp string, addresses ...string) (*OvnCommand, error) {
 	return c.lspSetAddressImp(lsp, addresses...)
+}
+
+func (c *ovndb) LSPSetType(lsp string, portType string) (*OvnCommand, error) {
+	return c.lspSetTypeImp(lsp, portType)
 }
 
 func (c *ovndb) LSPSetPortSecurity(lsp string, security ...string) (*OvnCommand, error) {

--- a/client.go
+++ b/client.go
@@ -28,8 +28,9 @@ import (
 )
 
 type EntityType string
-const(
-	PORT_GROUP EntityType = "PORT_GROUP"
+
+const (
+	PORT_GROUP     EntityType = "PORT_GROUP"
 	LOGICAL_SWITCH EntityType = "LOICAL_SWITCH"
 )
 
@@ -48,6 +49,10 @@ type Client interface {
 	LSExtIdsAdd(ls string, external_ids map[string]string) (*OvnCommand, error)
 	// Del external_ids from logical_switch
 	LSExtIdsDel(ls string, external_ids map[string]string) (*OvnCommand, error)
+	// Add external_ids or other_config records to logical switch
+	LSAuxAdd(ls string, auxConf map[string]string, auxTable string) (*OvnCommand, error)
+	// Del external_ids or other_config from logical_switch
+	LSAuxDel(ls string, auxConf map[string]string, auxTable string) (*OvnCommand, error)
 	// Link logical switch to router
 	LinkSwitchToRouter(lsw, lsp, lr, lrp, lrpMac string, networks []string, externalIds map[string]string) (*OvnCommand, error)
 
@@ -420,6 +425,14 @@ func (c *ovndb) LSExtIdsAdd(ls string, external_ids map[string]string) (*OvnComm
 
 func (c *ovndb) LSExtIdsDel(ls string, external_ids map[string]string) (*OvnCommand, error) {
 	return c.lsExtIdsDelImp(ls, external_ids)
+}
+
+func (c *ovndb) LSAuxAdd(ls string, auxConf map[string]string, auxTable string) (*OvnCommand, error) {
+	return c.lsAuxAddImp(ls, auxConf, auxTable)
+}
+
+func (c *ovndb) LSAuxDel(ls string, auxConf map[string]string, auxTable string) (*OvnCommand, error) {
+	return c.lsAuxDelImp(ls, auxConf, auxTable)
 }
 
 func (c *ovndb) LSPGet(lsp string) (*LogicalSwitchPort, error) {

--- a/logical_switch_port.go
+++ b/logical_switch_port.go
@@ -131,6 +131,20 @@ func (odbi *ovndb) lspSetAddressImp(lsp string, addr ...string) (*OvnCommand, er
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
+func (odbi *ovndb) lspSetTypeImp(lsp string, portType string) (*OvnCommand, error) {
+	row := make(OVNRow)
+	row["type"] = portType
+	condition := libovsdb.NewCondition("name", "==", lsp)
+	updateOp := libovsdb.Operation{
+		Op:    opUpdate,
+		Table: TableLogicalSwitchPort,
+		Row:   row,
+		Where: []interface{}{condition},
+	}
+	operations := []libovsdb.Operation{updateOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
 func (odbi *ovndb) lspSetPortSecurityImp(lsp string, security ...string) (*OvnCommand, error) {
 	row := make(OVNRow)
 	port_security, err := libovsdb.NewOvsSet(security)


### PR DESCRIPTION
in some cases, we need to update other_config record with key/values specific to a logical entity. For example, DHCP parameters such as subnet CIDR and exclude_ips live in logical switch'es other_config record. Currently, there's no API methods to update other_config. This PR provides "Add" and "Del" methods (LSAux{Add,Del}) that can operate either on external_ids or other_config records by providing the corresponding parameter. Also, added LSP Type setter, so we can modify port type (e.g, when we want to set localnet type for the port)