### PR TITLE
Add support for LS other_config; setter for LSP type

### DIFF
--- a/client.go
+++ b/client.go
@@ -49,6 +49,10 @@ type Client interface {
 	LSExtIdsAdd(ls string, external_ids map[string]string) (*OvnCommand, error)
 	// Del external_ids from logical_switch
 	LSExtIdsDel(ls string, external_ids map[string]string) (*OvnCommand, error)
+	// Add keys/vals to logical switch external_ids or other_config records
+	LSAuxAdd(ls string, auxConf map[string]string, auxColumn string) (*OvnCommand, error)
+	// Remove keys/vals from logical switch external_ids or other_config records
+	LSAuxDel(ls string, auxConf map[string]string, auxColumn string) (*OvnCommand, error)
 	// Link logical switch to router
 	LinkSwitchToRouter(lsw, lsp, lr, lrp, lrpMac string, networks []string, externalIds map[string]string) (*OvnCommand, error)
 
@@ -444,6 +448,14 @@ func (c *ovndb) LSExtIdsAdd(ls string, external_ids map[string]string) (*OvnComm
 
 func (c *ovndb) LSExtIdsDel(ls string, external_ids map[string]string) (*OvnCommand, error) {
 	return c.lsExtIdsDelImp(ls, external_ids)
+}
+
+func (c *ovndb) LSAuxAdd(ls string, auxConf map[string]string, auxColumn string) (*OvnCommand, error) {
+	return c.lsAuxAddImp(ls, auxConf, auxColumn)
+}
+
+func (c *ovndb) LSAuxDel(ls string, auxConf map[string]string, auxColumn string) (*OvnCommand, error) {
+	return c.lsAuxDelImp(ls, auxConf, auxColumn)
 }
 
 func (c *ovndb) LSPGet(lsp string) (*LogicalSwitchPort, error) {

--- a/client.go
+++ b/client.go
@@ -66,6 +66,8 @@ type Client interface {
 	LSPSetAddress(lsp string, addresses ...string) (*OvnCommand, error)
 	// Set port security per lport
 	LSPSetPortSecurity(lsp string, security ...string) (*OvnCommand, error)
+	// Set lport type
+	LSPSetType(lsp string, portType string) (*OvnCommand, error)
 	// Get all lport by lswitch
 	LSPList(ls string) ([]*LogicalSwitchPort, error)
 
@@ -480,6 +482,10 @@ func (c *ovndb) LSPSetAddress(lsp string, addresses ...string) (*OvnCommand, err
 
 func (c *ovndb) LSPSetPortSecurity(lsp string, security ...string) (*OvnCommand, error) {
 	return c.lspSetPortSecurityImp(lsp, security...)
+}
+
+func (c *ovndb) LSPSetType(lsp string, portType string) (*OvnCommand, error) {
+	return c.lspSetTypeImp(lsp, portType)
 }
 
 func (c *ovndb) LSPSetDHCPv4Options(lsp string, options string) (*OvnCommand, error) {

--- a/logical_switch_port.go
+++ b/logical_switch_port.go
@@ -131,6 +131,20 @@ func (odbi *ovndb) lspSetAddressImp(lsp string, addr ...string) (*OvnCommand, er
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 
+func (odbi *ovndb) lspSetTypeImp(lsp string, portType string) (*OvnCommand, error) {
+	row := make(OVNRow)
+	row["type"] = portType
+	condition := libovsdb.NewCondition("name", "==", lsp)
+	updateOp := libovsdb.Operation{
+		Op:    opUpdate,
+		Table: TableLogicalSwitchPort,
+		Row:   row,
+		Where: []interface{}{condition},
+	}
+	operations := []libovsdb.Operation{updateOp}
+	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
+}
+
 func (odbi *ovndb) lspSetPortSecurityImp(lsp string, security ...string) (*OvnCommand, error) {
 	row := make(OVNRow)
 	port_security, err := libovsdb.NewOvsSet(security)


### PR DESCRIPTION
1) New methods for Add/Del key/val to LS external_ids, other_config. The latter is needed to set DHCP parameters.
2) New method to set LSP type (e.g., needed for 'localnet')