### PR TITLE
Extend ACL API to support changing match critera and logging for an existing ACL

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,15 +73,21 @@ type Client interface {
 	LSLBList(ls string) ([]*LoadBalancer, error)
 
 	// Add ACL to entity (PORT_GROUP or LOGICAL_SWITCH)
-	ACLAddEntity(entityType EntityType, entity, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter string, severity string) (*OvnCommand, error)
+	ACLAddEntity(entityType EntityType, entityName, aclName, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter, severity string) (*OvnCommand, error)
 	// Deprecated in favor of ACLAddEntity(). Add ACL to logical switch.
 	ACLAdd(ls, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter string, severity string) (*OvnCommand, error)
+	// Set name for ACL
+	ACLSetName(aclUUID, aclName string) (*OvnCommand, error)
+	// Set match criteria for ACL
+	ACLSetMatch(aclUUID, newMatch string) (*OvnCommand, error)
+	// Set logging for ACL
+	ACLSetLogging(aclUUID string, newLogflag bool, newMeter, newSeverity string) (*OvnCommand, error)
 	// Delete acl from entity (PORT_GROUP or LOGICAL_SWITCH)
-	ACLDelEntity(entityType EntityType, entity, direct, match string, priority int, external_ids map[string]string) (*OvnCommand, error)
+	ACLDelEntity(entityType EntityType, entityName, aclUUID string) (*OvnCommand, error)
 	// Deprecated in favor of ACLDelEntity(). Delete acl from logical switch
 	ACLDel(ls, direct, match string, priority int, external_ids map[string]string) (*OvnCommand, error)
 	// Get all acl by entity
-	ACLListEntity(entityType EntityType, entity string) ([]*ACL, error)
+	ACLListEntity(entityType EntityType, entityName string) ([]*ACL, error)
 	// Deprecated in favor of ACLListEntity(). Get all acl by logical switch
 	ACLList(ls string) ([]*ACL, error)
 
@@ -620,16 +626,28 @@ func (c *ovndb) LBList() ([]*LoadBalancer, error) {
 	return c.lbListImp()
 }
 
-func (c *ovndb) ACLAddEntity(entityType EntityType, entity, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter string, severity string) (*OvnCommand, error) {
-	return c.aclAddImp(entityType, entity, direct, match, action, priority, external_ids, logflag, meter, severity)
+func (c *ovndb) ACLAddEntity(entityType EntityType, entityName, aclName, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter, severity string) (*OvnCommand, error) {
+	return c.aclAddImp(entityType, entityName, aclName, direct, match, action, priority, external_ids, logflag, meter, severity)
 }
 
 func (c *ovndb) ACLAdd(ls, direct, match, action string, priority int, external_ids map[string]string, logflag bool, meter string, severity string) (*OvnCommand, error) {
-	return c.aclAddImp(LOGICAL_SWITCH, ls, direct, match, action, priority, external_ids, logflag, meter, severity)
+	return c.aclAddImp(LOGICAL_SWITCH, ls, "", direct, match, action, priority, external_ids, logflag, meter, severity)
 }
 
-func (c *ovndb) ACLDelEntity(entityType EntityType, entity, direct, match string, priority int, external_ids map[string]string) (*OvnCommand, error) {
-	return c.aclDelImp(entityType, entity, direct, match, priority, external_ids)
+func (c *ovndb) ACLSetName(aclUUID, aclName string) (*OvnCommand, error) {
+	return c.aclSetNameImp(aclUUID, aclName)
+}
+
+func (c *ovndb) ACLSetMatch(aclUUID, newMatch string) (*OvnCommand, error) {
+	return c.aclSetMatchImp(aclUUID, newMatch)
+}
+
+func (c *ovndb) ACLSetLogging(aclUUID string, newLogflag bool, newMeter, newSeverity string) (*OvnCommand, error) {
+	return c.aCLSetLoggingImp(aclUUID, newLogflag, newMeter, newSeverity)
+}
+
+func (c *ovndb) ACLDelEntity(entityType EntityType, entityName, aclUUID string) (*OvnCommand, error) {
+	return c.aclDelUUIDImp(entityType, entityName, aclUUID)
 }
 
 func (c *ovndb) ACLDel(ls, direct, match string, priority int, external_ids map[string]string) (*OvnCommand, error) {

--- a/meter_test.go
+++ b/meter_test.go
@@ -4,12 +4,6 @@ import (
 	"testing"
 )
 
-const (
-	METER1 = "testMeter1"
-	METER2 = "testMeter2"
-	METER3 = "testMeter3"
-)
-
 func TestMeter(t *testing.T) {
 	ovndbapi := getOVNClient(DBNB)
 	var cmds []*OvnCommand

--- a/test_common.go
+++ b/test_common.go
@@ -61,6 +61,18 @@ const (
 	PG_TEST_ID_2         = "169.254.1.1"
 	PG_TEST_KEY_3        = "foo1"
 	PG_TEST_ID_3         = "bar1"
+	ACL_NAME_1           = "aclName1"
+	ACL_NAME_2           = "aclName2"
+	ACL_NAME_3           = "aclName3"
+	ACL_NAME_4           = "aclName4"
+	ACL_NAME_5           = "aclName5"
+	SEVERITY_INFO        = "info"
+	SEVERITY_ALERT       = "alert"
+	SEVERITY_WARNING     = "warning"
+	METER1               = "testMeter1"
+	METER2               = "testMeter2"
+	METER3               = "testMeter3"
+	NONEXISTENT_UUID     = "53be5050-87b2-49d4-9c74-bf645653a524"
 )
 
 var (


### PR DESCRIPTION
- Support setting ACL name in ACLAddEntity()
- Add ACL set support for ACL name, match and logging for an existing ACL
- Use ACL UUID to identify ACL in ACLDelEntity()

Addresses Issues #137 and #138

Signed-off-by: Andre Fredette <afredette@redhat.com>