### PR TITLE
Connect - reconnect cache correctness

### DIFF
--- a/client.go
+++ b/client.go
@@ -314,6 +314,9 @@ func connect(c *ovndb) (err error) {
 	notifier := ovnNotifier{c}
 	ovsdb.Register(notifier)
 
+	// When we connect we initialize the cache, so any deletions
+	// happened while reconnecting are handled correctly.
+	c.cache = make(map[string]map[string]libovsdb.Row)
 	initial, err := c.MonitorTables("")
 	if err != nil {
 		return err
@@ -337,7 +340,6 @@ func NewClient(cfg *Config) (Client, error) {
 	}
 
 	ovndb := &ovndb{
-		cache:        make(map[string]map[string]libovsdb.Row),
 		signalCB:     cfg.SignalCB,
 		disconnectCB: cfg.DisconnectCB,
 		db:           db,

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -227,9 +227,6 @@ func (odbi *ovndb) float64_to_int(row libovsdb.Row) {
 func (odbi *ovndb) populateCache(updates libovsdb.TableUpdates) {
 	empty := libovsdb.Row{}
 
-	odbi.cachemutex.Lock()
-	defer odbi.cachemutex.Unlock()
-
 	for table := range odbi.tableCols {
 		tableUpdate, ok := updates.Updates[table]
 		if !ok {

--- a/ovnnotify.go
+++ b/ovnnotify.go
@@ -25,6 +25,8 @@ type ovnNotifier struct {
 }
 
 func (notify ovnNotifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
+	notify.odbi.cachemutex.Lock()
+	defer notify.odbi.cachemutex.Unlock()
 	notify.odbi.populateCache(tableUpdates)
 }
 func (notify ovnNotifier) Locked([]interface{}) {


### PR DESCRIPTION
Two fixes here:
- we wipe out the cache when reconnecting (this is because we don't get the "deletion" events from MonitorTables
- we setup the notifier before fetching the db dump and initializing the cache. This avoid missed events in between