### PR TITLE
no need to destroy LSP row when also removing from LS' ports column

### DIFF
--- a/logical_switch_port.go
+++ b/logical_switch_port.go
@@ -85,12 +85,6 @@ func (odbi *ovndb) lspDelImp(lsp string) (*OvnCommand, error) {
 	}
 
 	mutateUUID := []libovsdb.UUID{stringToGoUUID(lspUUID)}
-	condition := libovsdb.NewCondition("name", "==", lsp)
-	deleteOp := libovsdb.Operation{
-		Op:    opDelete,
-		Table: TableLogicalSwitchPort,
-		Where: []interface{}{condition},
-	}
 	mutateSet, err := libovsdb.NewOvsSet(mutateUUID)
 	if err != nil {
 		return nil, err
@@ -109,7 +103,7 @@ func (odbi *ovndb) lspDelImp(lsp string) (*OvnCommand, error) {
 		Mutations: []interface{}{mutation},
 		Where:     []interface{}{mucondition},
 	}
-	operations := []libovsdb.Operation{deleteOp, mutateOp}
+	operations := []libovsdb.Operation{mutateOp}
 	return &OvnCommand{operations, odbi, make([][]map[string]interface{}, len(operations))}, nil
 }
 


### PR DESCRIPTION
it is just sufficient to remove the LSP's UUID from the LS's Ports
column, and this in itself will remove the LSP from the table since
LSP can't be present by itself

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>

@hzhou8 @noah8713 PTAL