### PR TITLE
In pgUpdateImp method, check for port slice length instead of checkin…

### DIFF
--- a/port_group.go
+++ b/port_group.go
@@ -82,11 +82,11 @@ func (odbi *ovndb) pgUpdateImp(group string, ports []string, external_ids map[st
 		return nil, ErrorNotFound
 	}
 
-	if ports == nil && external_ids == nil {
+	if len(ports) == 0 && external_ids == nil {
 		return nil, ErrorNoChanges
 	}
 
-	if ports != nil {
+	if len(ports) > 0 {
 		portUUIDs := make([]libovsdb.UUID, 0, len(ports))
 		for _, u := range ports {
 			portUUIDs = append(portUUIDs, stringToGoUUID(u))


### PR DESCRIPTION
…g whether ports slice is nil

If we check for whether port is nil, in this case, there can be possibility of port
not being nil and the port slice len is 0 (if port is created using make([]string, 0, 0)).
Then, we are observing below error
 - Transaction Failed due to an error: syntax error details: expected ["set", <array>] in
   {update Port_Group map[name:<a17069877248180744570> ports:0xc00052c528] [] [] [] 0 [[name == a17069877248180744570]]  }

Signed-off-by: Pardhakeswar Pacha <ppacha@nvidia.com>