### PR TITLE
Remove transaction mutex

### DIFF
--- a/client.go
+++ b/client.go
@@ -281,7 +281,6 @@ type ovndb struct {
 	client       *libovsdb.OvsdbClient
 	cache        map[string]map[string]libovsdb.Row
 	cachemutex   sync.RWMutex
-	tranmutex    sync.Mutex
 	signalCB     OVNSignal
 	disconnectCB OVNDisconnectedCallback
 	db           string

--- a/ovnimp.go
+++ b/ovnimp.go
@@ -146,9 +146,6 @@ func (odbi *ovndb) getRowsMatchingUUID(table, field, uuid string) ([]string, err
 }
 
 func (odbi *ovndb) transact(db string, ops ...libovsdb.Operation) ([]libovsdb.OperationResult, error) {
-	// Only support one trans at same time now.
-	odbi.tranmutex.Lock()
-	defer odbi.tranmutex.Unlock()
 	reply, err := odbi.client.Transact(db, ops...)
 
 	if err != nil {


### PR DESCRIPTION
The transaction mutex is not necessary, because the rpc2 lib and ovsdb
protocol ensure that a cache/db update is received before the
transaction is complete, and every transaction is serialized.

Signed-off-by: Tim Rozet <trozet@redhat.com>